### PR TITLE
Fix: set start_date on automated test runs created via GitLab CI trigger

### DIFF
--- a/src/app/api/integrations/gitlab/trigger/route.ts
+++ b/src/app/api/integrations/gitlab/trigger/route.ts
@@ -98,6 +98,7 @@ export async function POST(req: Request) {
       is_automated: true,
       source: "ci_trigger",
       created_by: user.id,
+      start_date: new Date().toISOString(),
     })
     .select()
     .single();


### PR DESCRIPTION
## Summary

- Automated runs created via \"Trigger Automated Run\" had no `start_date`, leaving the Start Date column blank in the grid
- Added `start_date: new Date().toISOString()` to the insert in the GitLab CI trigger route
- Validated with Playwright: new run appears at the top of the table sorted by today's date

## Test plan
- [ ] Click \"Trigger Automated Run\" on /runs, fill in project/suite, submit
- [ ] Confirm the new run shows today's date in the Start Date column
- [ ] Confirm it sorts to the top (descending by start_date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)