### PR TITLE
feat: enrich auto-created runs with environment and pipeline URL

### DIFF
--- a/src/lib/webhooks/process-playwright.ts
+++ b/src/lib/webhooks/process-playwright.ts
@@ -175,6 +175,8 @@ export async function processPlaywrightWebhook(
       description: metadata?.ci_url
         ? `Automated run from CI: ${metadata.ci_url}`
         : 'Automated run from Playwright webhook',
+      environment: (metadata?.environment as string) ?? null,
+      gitlab_pipeline_url: (metadata?.ci_url as string) ?? null,
       status: 'completed',
       is_automated: true,
       source: 'playwright_webhook',


### PR DESCRIPTION
## Summary

When `process-playwright.ts` auto-creates a run (no `test_run_id`), it now sets `environment` and `gitlab_pipeline_url` from webhook metadata.

## What changed

`src/lib/webhooks/process-playwright.ts` — 2 fields added to the `.insert()` block:
- `environment`: mapped from branch name (e.g. `qa`, `uat`, `prod`)
- `gitlab_pipeline_url`: from `metadata.ci_url` (`CI_PIPELINE_URL`)

## Why

Runs created by standard merge/manual CI pipelines (via the `e2e-test` job) were missing environment and pipeline URL. This pairs with the GitLab CI enrichment in MR !493 on the marketplace repo.

## Ref
Pipeline URL Visibility for Webhook-Created Runs