### PR TITLE
fix: correct baseQuery() method chain in TestCaseRepository

### DIFF
--- a/src/lib/db/test-case-repository.ts
+++ b/src/lib/db/test-case-repository.ts
@@ -18,8 +18,7 @@ export class TestCaseRepository {
 
   /** Default scope: active (not deleted) test cases only. */
   private baseQuery() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (this.db.from('test_cases') as any).is('deleted_at', null);
+    return this.db.from('test_cases').select('*').is('deleted_at', null);
   }
 
   /** Find a single active test case by ID. Returns null if deleted or missing. */
@@ -50,7 +49,11 @@ export class TestCaseRepository {
 
   /** List active test cases, optionally filtered. */
   async findAll(filters: TestCaseFilters = {}) {
-    let query = this.baseQuery().select('*, suite:suites(project_id)').order('position', { ascending: true });
+    let query = this.db
+      .from('test_cases')
+      .select('*, suite:suites(project_id)')
+      .is('deleted_at', null)
+      .order('position', { ascending: true });
 
     for (const [key, value] of Object.entries(filters)) {
       if (value !== undefined && value !== null) {


### PR DESCRIPTION
Call .select() before .is() so filter methods are available on the PostgrestFilterBuilder. The previous code called .is() directly on PostgrestQueryBuilder which doesn't expose filter methods, causing a TypeError at runtime and breaking the test suite detail view.

Also cleaned up a redundant .select() call in findAll() by building the query directly with the correct chain order.

Fixes: test cases and steps not rendering in suite detail view.