### PR TITLE
fix: Issue #24 — reorder reverts because grid indices were applied to unsorted testCases array

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/suites/[suiteId]/page.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/suites/[suiteId]/page.tsx
@@ -320,7 +320,10 @@ export default function SuiteViewPage() {
   const handleRowOrderChange = useCallback(
     async (params: GridRowOrderChangeParams) => {
       const { oldIndex, targetIndex } = params;
-      const reordered = [...testCases];
+      // Sort by position to match the grid's rendered order (sortModel: position ASC).
+      // testCases state is in fetch order which may not match position order —
+      // using raw indices against the unsorted array moves the wrong item.
+      const reordered = [...testCases].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
       const [moved] = reordered.splice(oldIndex, 1);
       reordered.splice(targetIndex, 0, moved);
 


### PR DESCRIPTION
## Summary

Closes #24

One-line fix. Gap analysis confirmed the cause before any code was written.

## Root cause

The DataGrid is configured with `sortModel: [{ field: 'position', sort: 'asc' }]` when `rowReordering=true`. It renders rows in position order and reports `oldIndex`/`targetIndex` relative to that sorted order.

`handleRowOrderChange` was doing:
```ts
const reordered = [...testCases]; // fetch order — NOT position order
reordered.splice(oldIndex, 1);    // wrong item
```

`testCases` state is in fetch order, which doesn't necessarily match position order. Splicing by grid indices against an unsorted array picks the wrong item, producing a garbled ID array sent to the reorder RPC. The DB stores the garbled order. On the next `fetchTestCases` call the DB's (wrong) state is loaded, which appears as a revert to the user.

## Fix

Sort `testCases` by `position` before splicing, so indices align with the grid's rendered order:

```ts
const reordered = [...testCases].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
```

This is a one-line change with a clear comment explaining why the sort is necessary.