### PR TITLE
fix: reorder_test_cases RPC missing SECURITY DEFINER — RLS silently blocking all writes

### DIFF
--- a/supabase/migrations/00017_reorder_rpc_security_definer.sql
+++ b/supabase/migrations/00017_reorder_rpc_security_definer.sql
@@ -1,0 +1,84 @@
+-- Migration: Add SECURITY DEFINER to reorder_test_cases RPC
+-- ============================================================
+-- Without SECURITY DEFINER, the function runs as SECURITY INVOKER and is
+-- subject to RLS on test_cases and suites. The UPDATE statements inside the
+-- function are silently filtered by the RLS USING clause (auth_role() check),
+-- resulting in 0 rows updated — the reorder appears to succeed (returns a
+-- version number) but nothing is persisted.
+--
+-- All other functions that write to test_cases (generate_test_case_id,
+-- snapshot_test_case_version, update_test_case_display_ids_on_prefix_change)
+-- use SECURITY DEFINER. This migration brings reorder_test_cases in line.
+--
+-- SET search_path = public prevents search_path injection attacks, consistent
+-- with all other SECURITY DEFINER functions in this project.
+
+CREATE OR REPLACE FUNCTION reorder_test_cases(
+  p_suite_id    uuid,
+  p_ordered_ids uuid[]
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_new_version  integer;
+  v_has_cicd     boolean;
+  v_suite_prefix text;
+BEGIN
+  -- Check if any active test case in this suite is in_cicd
+  SELECT EXISTS (
+    SELECT 1
+      FROM test_cases
+     WHERE suite_id         = p_suite_id
+       AND deleted_at       IS NULL
+       AND automation_status = 'in_cicd'
+  ) INTO v_has_cicd;
+
+  -- Always: assign 1-based positions from the ordered array in a single UPDATE
+  UPDATE test_cases tc
+     SET position = ord.ordinal
+    FROM unnest(p_ordered_ids) WITH ORDINALITY AS ord(id, ordinal)
+   WHERE tc.id       = ord.id
+     AND tc.suite_id = p_suite_id
+     AND tc.deleted_at IS NULL;
+
+  IF NOT v_has_cicd THEN
+    -- Fetch the suite prefix for display_id construction
+    SELECT prefix INTO v_suite_prefix
+      FROM suites
+     WHERE id = p_suite_id;
+
+    -- First pass: stamp temp display_ids to clear the non-deferrable UNIQUE constraint
+    UPDATE test_cases tc
+       SET display_id = '__tmp__' || tc.id::text
+      FROM unnest(p_ordered_ids) WITH ORDINALITY AS ord(id, ordinal)
+     WHERE tc.id       = ord.id
+       AND tc.suite_id = p_suite_id
+       AND tc.deleted_at IS NULL;
+
+    -- Second pass: assign final display_id and sequence_number based on new ordinal
+    UPDATE test_cases tc
+       SET display_id      = v_suite_prefix || '-' || ord.ordinal,
+           sequence_number = ord.ordinal
+      FROM unnest(p_ordered_ids) WITH ORDINALITY AS ord(id, ordinal)
+     WHERE tc.id       = ord.id
+       AND tc.suite_id = p_suite_id
+       AND tc.deleted_at IS NULL;
+
+    -- Keep next_sequence one ahead of the highest assigned ordinal
+    UPDATE suites
+       SET next_sequence = array_length(p_ordered_ids, 1) + 1
+     WHERE id = p_suite_id;
+  END IF;
+
+  -- Increment reorder_version and capture the new value
+  UPDATE suites
+     SET reorder_version = reorder_version + 1
+   WHERE id = p_suite_id
+  RETURNING reorder_version INTO v_new_version;
+
+  RETURN COALESCE(v_new_version, 0);
+END;
+$$;


### PR DESCRIPTION
## Root cause

The `reorder_test_cases` function was created without `SECURITY DEFINER`. This means it runs as `SECURITY INVOKER` — subject to Row Level Security on `test_cases` and `suites`.

The RLS `UPDATE` policies on both tables require:
```sql
auth_role() IN ('admin', 'qa_engineer', 'sdet')
```

Inside the PL/pgSQL function, `auth_role()` performs a lookup against the `profiles` table. When called via Supabase RPC from a Next.js server route, the auth context may not resolve correctly inside the function body — the `UPDATE` statements silently match 0 rows. The function still returns a version number (the `suites` UPDATE has the same issue, returning `COALESCE(null, 0) = 0`), so the API route sees a successful response and returns the (unchanged) test case list. The UI briefly shows the optimistic update, then reverts when the server data loads.

Every other function that writes to `test_cases` in this project uses `SECURITY DEFINER SET search_path = public` — `generate_test_case_id`, `snapshot_test_case_version`, `update_test_case_display_ids_on_prefix_change`. This was an oversight when the reorder function was written.

## Fix

Migration `00017` adds `SECURITY DEFINER SET search_path = public` to `reorder_test_cases`. Full function body is identical to `00016` — only the security mode changes.

## Why this wasn't caught earlier

The function was tested in a context where the caller had sufficient privileges for the INVOKER path to work, or the RLS filtering appeared as a silent no-op rather than an error. The pattern of using SECURITY DEFINER was established for all other write functions but wasn't applied consistently here.