### PR TITLE
fix(#16): Show test data in run execution UI and add step comment field

### DIFF
--- a/src/app/(dashboard)/runs/[runId]/execute/[caseId]/page.tsx
+++ b/src/app/(dashboard)/runs/[runId]/execute/[caseId]/page.tsx
@@ -23,7 +23,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
-import ExecutionMatrix, { type ResultMap, type BrowserResultMap } from '@/components/execution/ExecutionMatrix';
+import ExecutionMatrix, { type ResultMap, type BrowserResultMap, type ResultEntry } from '@/components/execution/ExecutionMatrix';
 import AnnotationPanel from '@/components/execution/AnnotationPanel';
 import { useAuth } from '@/components/providers/AuthProvider';
 import type { TestCase, TestStep, ExecutionStatus, Platform, ExecutionResult } from '@/types/database';
@@ -82,7 +82,7 @@ export default function ExecuteCasePage() {
         browserSet.add(browser);
         if (!bMap[r.test_step_id]) bMap[r.test_step_id] = {};
         if (!bMap[r.test_step_id][r.platform]) bMap[r.test_step_id][r.platform] = {};
-        bMap[r.test_step_id][r.platform][browser] = { status: r.status, id: r.id };
+        bMap[r.test_step_id][r.platform][browser] = { status: r.status, id: r.id, comment: r.comment };
         if (r.status === 'fail') {
           failedIds[`${r.test_step_id}_${r.platform}_${browser}`] = r.id;
         }
@@ -100,20 +100,28 @@ export default function ExecuteCasePage() {
     if (!authLoading) fetchData();
   }, [authLoading, fetchData]);
 
-  const handleStatusChange = async (stepId: string, platform: Platform, newStatus: ExecutionStatus) => {
+  const handleStatusChange = async (stepId: string, platform: Platform, newStatus: ExecutionStatus, comment?: string | null) => {
     if (!testCase) return;
 
-    setBrowserResults((prev) => ({
-      ...prev,
-      [stepId]: {
-        ...prev[stepId],
-        [platform]: {
-          ...prev[stepId]?.[platform],
-          [selectedBrowser]: { ...prev[stepId]?.[platform]?.[selectedBrowser], status: newStatus },
+    setBrowserResults((prev) => {
+      const prev_entry = prev[stepId]?.[platform]?.[selectedBrowser] ?? {} as ResultEntry;
+      return {
+        ...prev,
+        [stepId]: {
+          ...prev[stepId],
+          [platform]: {
+            ...prev[stepId]?.[platform],
+            [selectedBrowser]: {
+              ...prev_entry,
+              status: newStatus,
+              comment: comment !== undefined ? comment : prev_entry.comment,
+            },
+          },
         },
-      },
-    }));
+      };
+    });
 
+    const currentComment = browserResults[stepId]?.[platform]?.[selectedBrowser]?.comment;
     await fetch(`/api/test-runs/${runId}/results`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -124,6 +132,7 @@ export default function ExecuteCasePage() {
           platform,
           browser: selectedBrowser,
           status: newStatus,
+          comment: comment !== undefined ? comment : currentComment ?? null,
         }],
       }),
     });
@@ -150,6 +159,22 @@ export default function ExecuteCasePage() {
       }
       setFailedResultIds(failedIds);
     }
+  };
+
+  const handleCommentChange = (stepId: string, platform: Platform, comment: string) => {
+    setBrowserResults((prev) => {
+      const prev_entry = prev[stepId]?.[platform]?.[selectedBrowser] ?? {} as ResultEntry;
+      return {
+        ...prev,
+        [stepId]: {
+          ...prev[stepId],
+          [platform]: {
+            ...prev[stepId]?.[platform],
+            [selectedBrowser]: { ...prev_entry, comment },
+          },
+        },
+      };
+    });
   };
 
   const handleAddBrowser = () => {
@@ -240,6 +265,7 @@ export default function ExecuteCasePage() {
             selectedBrowser={selectedBrowser}
             onBrowserChange={setSelectedBrowser}
             onStatusChange={handleStatusChange}
+            onCommentChange={handleCommentChange}
             readOnly={readOnly}
           />
         </Box>

--- a/src/app/api/test-runs/[runId]/results/route.ts
+++ b/src/app/api/test-runs/[runId]/results/route.ts
@@ -46,6 +46,7 @@ export async function PUT(request: Request, context: RouteContext) {
     platform: r.platform,
     browser: r.browser ?? 'default',
     status: r.status,
+    comment: r.comment ?? null,
     executed_by: user.id,
     executed_at: now,
   }));

--- a/src/components/execution/ExecutionMatrix.tsx
+++ b/src/components/execution/ExecutionMatrix.tsx
@@ -11,27 +11,28 @@ import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import TextField from '@mui/material/TextField';
 import { alpha } from '@mui/material/styles';
 import { palette, semanticColors } from '@/theme/palette';
 import ExecutionStatusCell from './ExecutionStatusCell';
 import type { ExecutionStatus, Platform, TestStep } from '@/types/database';
 
+export interface ResultEntry {
+  status: ExecutionStatus;
+  id?: string;
+  comment?: string | null;
+}
+
 export interface ResultMap {
   [stepId: string]: {
-    [platform: string]: {
-      status: ExecutionStatus;
-      id?: string;
-    };
+    [platform: string]: ResultEntry;
   };
 }
 
 export interface BrowserResultMap {
   [stepId: string]: {
     [platform: string]: {
-      [browser: string]: {
-        status: ExecutionStatus;
-        id?: string;
-      };
+      [browser: string]: ResultEntry;
     };
   };
 }
@@ -44,7 +45,8 @@ interface ExecutionMatrixProps {
   browsers?: string[];
   selectedBrowser?: string;
   onBrowserChange?: (browser: string) => void;
-  onStatusChange: (stepId: string, platform: Platform, status: ExecutionStatus) => void;
+  onStatusChange: (stepId: string, platform: Platform, status: ExecutionStatus, comment?: string | null) => void;
+  onCommentChange?: (stepId: string, platform: Platform, comment: string) => void;
   readOnly?: boolean;
 }
 
@@ -55,7 +57,7 @@ const PLATFORM_LABELS: Record<Platform, string> = {
 };
 
 export default function ExecutionMatrix({
-  steps, platforms, results, browsers, selectedBrowser, onBrowserChange, onStatusChange, readOnly,
+  steps, platforms, results, browsers, selectedBrowser, onBrowserChange, onStatusChange, onCommentChange, readOnly,
 }: ExecutionMatrixProps) {
   return (
     <Box>
@@ -91,7 +93,7 @@ export default function ExecutionMatrix({
                   sx={{
                     fontWeight: 600,
                     fontSize: '0.75rem',
-                    width: 120,
+                    width: 160,
                     color: platColor,
                     bgcolor: alpha(platColor, 0.05),
                     borderBottom: `2px solid ${platColor}`,
@@ -109,9 +111,10 @@ export default function ExecutionMatrix({
               key={step.id}
               sx={{
                 bgcolor: step.is_automation_only ? alpha(palette.info.main, 0.03) : 'transparent',
+                verticalAlign: 'top',
               }}
             >
-              <TableCell>
+              <TableCell sx={{ pt: 1.5 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                   <Typography variant="caption" sx={{ fontWeight: 700, color: 'text.secondary' }}>
                     {step.step_number}
@@ -131,26 +134,79 @@ export default function ExecutionMatrix({
                   )}
                 </Box>
               </TableCell>
-              <TableCell>
+              <TableCell sx={{ pt: 1.5 }}>
                 <Typography variant="body2" sx={{ fontSize: '0.8125rem' }}>
                   {step.description}
                 </Typography>
                 {step.expected_result && (
-                  <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block' }}>
+                  <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mt: 0.25 }}>
                     Expected: {step.expected_result}
                   </Typography>
+                )}
+                {step.test_data && (
+                  <Box
+                    sx={{
+                      mt: 0.5,
+                      px: 1,
+                      py: 0.25,
+                      borderRadius: '4px',
+                      bgcolor: alpha(palette.info.main, 0.08),
+                      border: `1px solid ${alpha(palette.info.main, 0.2)}`,
+                      display: 'inline-block',
+                    }}
+                  >
+                    <Typography variant="caption" sx={{ fontWeight: 600, color: palette.info.main }}>
+                      Test Data:
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: 'text.primary', ml: 0.5 }}>
+                      {step.test_data}
+                    </Typography>
+                  </Box>
                 )}
               </TableCell>
               {platforms.map((p) => {
                 const result = results[step.id]?.[p];
                 const status = result?.status ?? 'not_run';
+                const comment = result?.comment ?? '';
                 return (
-                  <TableCell key={p} align="center">
+                  <TableCell key={p} align="center" sx={{ pt: 1.5 }}>
                     <ExecutionStatusCell
                       status={status}
                       onChange={(newStatus) => onStatusChange(step.id, p, newStatus)}
                       readOnly={readOnly}
                     />
+                    {!readOnly && (
+                      <TextField
+                        size="small"
+                        multiline
+                        minRows={1}
+                        maxRows={3}
+                        placeholder="Add note…"
+                        value={comment}
+                        onChange={(e) => onCommentChange?.(step.id, p, e.target.value)}
+                        onBlur={(e) => {
+                          const val = e.target.value;
+                          if (val !== (result?.comment ?? '')) {
+                            onStatusChange(step.id, p, status, val || null);
+                          }
+                        }}
+                        sx={{
+                          mt: 0.75,
+                          width: '100%',
+                          '& .MuiInputBase-root': { fontSize: '0.7rem', py: 0.5 },
+                          '& textarea': { resize: 'none' },
+                        }}
+                        inputProps={{ maxLength: 2000 }}
+                      />
+                    )}
+                    {readOnly && comment && (
+                      <Typography
+                        variant="caption"
+                        sx={{ display: 'block', mt: 0.5, color: 'text.secondary', fontStyle: 'italic', fontSize: '0.7rem', textAlign: 'left' }}
+                      >
+                        {comment}
+                      </Typography>
+                    )}
                   </TableCell>
                 );
               })}

--- a/src/lib/validations/execution-result.ts
+++ b/src/lib/validations/execution-result.ts
@@ -9,6 +9,7 @@ export const upsertResultSchema = z.object({
   platform: platformEnum,
   browser: z.string().trim().max(100).optional().default('default'),
   status: executionStatusEnum,
+  comment: z.string().trim().max(2000).nullable().optional(),
 });
 
 export const upsertResultsSchema = z.object({

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -153,6 +153,7 @@ export interface ExecutionResult {
   platform: Platform;
   browser: string;
   status: ExecutionStatus;
+  comment: string | null;
   executed_by: string | null;
   executed_at: string | null;
   duration_ms: number | null;

--- a/supabase/migrations/00019_execution_result_comment.sql
+++ b/supabase/migrations/00019_execution_result_comment.sql
@@ -1,0 +1,4 @@
+-- Migration: add optional comment field to execution_results
+-- Allows testers to record a note when marking a step Pass/Fail/Skip/Blocked.
+ALTER TABLE execution_results
+  ADD COLUMN IF NOT EXISTS comment text DEFAULT NULL;


### PR DESCRIPTION
## Summary

Fixes #16 — two related UX gaps in the test run execution view.

### Changes

#### 1. Test data now visible during execution
- `test_data` already existed on `TestStep` in the DB and type system but was never rendered.
- `ExecutionMatrix` now displays a highlighted badge (`Test Data: <value>`) directly below the step description and expected result for any step that has test data defined.

#### 2. Comment/notes field for Pass/Fail/Skip/Blocked
- Added a `comment` column (`text DEFAULT NULL`) to `execution_results` via migration `00019`.
- A compact multiline `TextField` (placeholder: "Add note…") now appears below each status cell in the matrix.
- Comment persists on `onBlur` by calling the existing `PUT /api/test-runs/[runId]/results` endpoint with the comment included.
- Read-only view shows the saved comment as italic caption text.
- Comments are carried per `(stepId, platform, browser)` — matching how statuses are tracked.

### Files changed
- `supabase/migrations/00019_execution_result_comment.sql` — adds `comment` column
- `src/types/database.ts` — adds `comment: string | null` to `ExecutionResult`
- `src/lib/validations/execution-result.ts` — adds optional `comment` to upsert schema
- `src/app/api/test-runs/[runId]/results/route.ts` — passes `comment` through to upsert
- `src/components/execution/ExecutionMatrix.tsx` — displays test_data badge + comment field
- `src/app/(dashboard)/runs/[runId]/execute/[caseId]/page.tsx` — wires comment state + handlers

### Migration notes
- Safe: `ADD COLUMN IF NOT EXISTS comment text DEFAULT NULL` — no impact on existing rows.
- Requires running `supabase db push` (or equivalent) in your environment.