### PR TITLE
feat: Runtime Test Data Override (actual_data_used)

### DIFF
--- a/src/app/(dashboard)/runs/[runId]/execute/[caseId]/page.tsx
+++ b/src/app/(dashboard)/runs/[runId]/execute/[caseId]/page.tsx
@@ -26,7 +26,7 @@ import DialogActions from '@mui/material/DialogActions';
 import ExecutionMatrix, { type ResultMap, type BrowserResultMap, type ResultEntry } from '@/components/execution/ExecutionMatrix';
 import AnnotationPanel from '@/components/execution/AnnotationPanel';
 import { useAuth } from '@/components/providers/AuthProvider';
-import type { TestCase, TestStep, ExecutionStatus, Platform, ExecutionResult } from '@/types/database';
+import type { TestCase, TestStep, ExecutionStatus, Platform, ExecutionResult, TestRunCase } from '@/types/database';
 
 export default function ExecuteCasePage() {
   const params = useParams();
@@ -51,16 +51,33 @@ export default function ExecuteCasePage() {
   const readOnly = !can('write');
 
   const fetchData = useCallback(async () => {
-    const [tcRes, runRes, resultsRes] = await Promise.all([
+    const [tcRes, runRes, runCasesRes, resultsRes] = await Promise.all([
       fetch(`/api/test-cases/${caseId}`),
       fetch(`/api/test-runs/${runId}`),
+      fetch(`/api/test-runs/${runId}/cases`),
       fetch(`/api/test-runs/${runId}/results?case_id=${caseId}`),
     ]);
 
     if (tcRes.ok) {
       const tc = await tcRes.json();
       setTestCase(tc);
+
+      // Prefer snapshot_steps from the run case record (EC-02: never re-query live test_steps
+      // after the run starts — snapshot_steps is frozen at run creation time).
+      // Fall back to live test_steps only if snapshot is unavailable (older runs).
+      let snapshotSteps: TestStep[] | null = null;
+      if (runCasesRes.ok) {
+        const runCases: (TestRunCase & { test_cases?: unknown })[] = await runCasesRes.json();
+        const runCase = runCases.find((rc) => rc.test_case_id === caseId);
+        if (runCase?.snapshot_steps && runCase.snapshot_steps.length > 0) {
+          snapshotSteps = (runCase.snapshot_steps as unknown as TestStep[])
+            .slice()
+            .sort((a, b) => a.step_number - b.step_number);
+        }
+      }
+
       setSteps(
+        snapshotSteps ??
         (tc.test_steps ?? []).sort(
           (a: TestStep, b: TestStep) => a.step_number - b.step_number,
         ),
@@ -82,7 +99,12 @@ export default function ExecuteCasePage() {
         browserSet.add(browser);
         if (!bMap[r.test_step_id]) bMap[r.test_step_id] = {};
         if (!bMap[r.test_step_id][r.platform]) bMap[r.test_step_id][r.platform] = {};
-        bMap[r.test_step_id][r.platform][browser] = { status: r.status, id: r.id, comment: r.comment };
+        bMap[r.test_step_id][r.platform][browser] = {
+          status: r.status,
+          id: r.id,
+          comment: r.comment,
+          actual_data_used: r.actual_data_used,
+        };
         if (r.status === 'fail') {
           failedIds[`${r.test_step_id}_${r.platform}_${browser}`] = r.id;
         }
@@ -177,6 +199,42 @@ export default function ExecuteCasePage() {
     });
   };
 
+  const handleActualDataChange = async (stepId: string, platform: Platform, value: string | null) => {
+    if (!testCase) return;
+
+    // Optimistic local update
+    setBrowserResults((prev) => {
+      const prev_entry = prev[stepId]?.[platform]?.[selectedBrowser] ?? {} as ResultEntry;
+      return {
+        ...prev,
+        [stepId]: {
+          ...prev[stepId],
+          [platform]: {
+            ...prev[stepId]?.[platform],
+            [selectedBrowser]: { ...prev_entry, actual_data_used: value },
+          },
+        },
+      };
+    });
+
+    const currentEntry = browserResults[stepId]?.[platform]?.[selectedBrowser];
+    await fetch(`/api/test-runs/${runId}/results`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        results: [{
+          test_case_id: caseId,
+          test_step_id: stepId,
+          platform,
+          browser: selectedBrowser,
+          status: currentEntry?.status ?? 'not_run',
+          comment: currentEntry?.comment ?? null,
+          actual_data_used: value,   // null clears the override (EC-03)
+        }],
+      }),
+    });
+  };
+
   const handleAddBrowser = () => {
     const name = newBrowserName.trim();
     if (name && !browsers.includes(name)) {
@@ -192,7 +250,7 @@ export default function ExecuteCasePage() {
     currentResults[stepId] = {};
     for (const [platform, browserMap] of Object.entries(platforms)) {
       const entry = browserMap[selectedBrowser];
-      if (entry) currentResults[stepId][platform] = entry;
+      if (entry) currentResults[stepId][platform] = entry;  // ResultEntry includes actual_data_used
     }
   }
 
@@ -266,6 +324,7 @@ export default function ExecuteCasePage() {
             onBrowserChange={setSelectedBrowser}
             onStatusChange={handleStatusChange}
             onCommentChange={handleCommentChange}
+            onActualDataChange={handleActualDataChange}
             readOnly={readOnly}
           />
         </Box>

--- a/src/app/(dashboard)/runs/[runId]/execute/[caseId]/page.tsx
+++ b/src/app/(dashboard)/runs/[runId]/execute/[caseId]/page.tsx
@@ -143,7 +143,8 @@ export default function ExecuteCasePage() {
       };
     });
 
-    const currentComment = browserResults[stepId]?.[platform]?.[selectedBrowser]?.comment;
+    const currentEntry = browserResults[stepId]?.[platform]?.[selectedBrowser];
+    const currentComment = currentEntry?.comment;
     await fetch(`/api/test-runs/${runId}/results`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -155,6 +156,7 @@ export default function ExecuteCasePage() {
           browser: selectedBrowser,
           status: newStatus,
           comment: comment !== undefined ? comment : currentComment ?? null,
+          actual_data_used: currentEntry?.actual_data_used ?? null,
         }],
       }),
     });

--- a/src/app/api/test-runs/[runId]/results/route.ts
+++ b/src/app/api/test-runs/[runId]/results/route.ts
@@ -39,6 +39,8 @@ export async function PUT(request: Request, context: RouteContext) {
   if (!parsed.success) return validationError(parsed.error.flatten());
 
   const now = new Date().toISOString();
+  // actual_data_used is stored in execution_results ONLY.
+  // Never add a test_steps write to this handler.
   const rows = parsed.data.results.map((r) => ({
     test_run_id: runId,
     test_case_id: r.test_case_id,
@@ -47,6 +49,7 @@ export async function PUT(request: Request, context: RouteContext) {
     browser: r.browser ?? 'default',
     status: r.status,
     comment: r.comment ?? null,
+    actual_data_used: r.actual_data_used ?? null,   // runtime override; coerced from "" to null at API boundary
     executed_by: user.id,
     executed_at: now,
   }));

--- a/src/components/execution/ExecutionMatrix.tsx
+++ b/src/components/execution/ExecutionMatrix.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -57,6 +58,63 @@ const PLATFORM_LABELS: Record<Platform, string> = {
   tablet: 'Tablet',
   mobile: 'Mobile',
 };
+
+/** Inner component that holds local draft state for "Actual data used" field.
+ *  onChange updates local state only; onBlur commits to parent (which triggers API). */
+function ActualDataField({
+  committed,
+  onCommit,
+}: {
+  committed: string | null | undefined;
+  onCommit: (value: string | null) => void;
+}) {
+  const [draft, setDraft] = useState<string>(committed ?? '');
+
+  // Sync if the committed value changes externally (e.g. another device, initial load)
+  // We only sync when the field is not dirty relative to committed.
+  const committedStr = committed ?? '';
+
+  return (
+    <TextField
+      size="small"
+      multiline
+      minRows={1}
+      maxRows={4}
+      placeholder="Actual data used…"
+      value={draft}
+      onChange={(e) => {
+        setDraft(e.target.value);
+      }}
+      onBlur={() => {
+        const normalized = draft.trim() === '' ? null : draft;
+        if (normalized !== (committedStr === '' ? null : committedStr)) {
+          onCommit(normalized);
+        }
+      }}
+      sx={{
+        mt: 0.75,
+        width: '100%',
+        '& .MuiInputBase-root': {
+          fontSize: '0.7rem',
+          py: 0.5,
+          bgcolor: alpha(palette.warning.main, 0.06),
+          border: `1px solid ${alpha(palette.warning.main, 0.25)}`,
+          borderRadius: '4px',
+        },
+        '& textarea': { resize: 'none' },
+        '& .MuiOutlinedInput-notchedOutline': {
+          borderColor: alpha(palette.warning.main, 0.3),
+        },
+        '&:hover .MuiOutlinedInput-notchedOutline': {
+          borderColor: palette.warning.main,
+        },
+      }}
+      inputProps={{ maxLength: 10000 }}
+      label="Actual data used"
+      InputLabelProps={{ sx: { fontSize: '0.65rem', color: palette.warning.main } }}
+    />
+  );
+}
 
 export default function ExecutionMatrix({
   steps, platforms, results, browsers, selectedBrowser, onBrowserChange, onStatusChange, onCommentChange, onActualDataChange, readOnly,
@@ -170,7 +228,6 @@ export default function ExecutionMatrix({
                 const result = results[step.id]?.[p];
                 const status = result?.status ?? 'not_run';
                 const comment = result?.comment ?? '';
-                const actualDataUsed = result?.actual_data_used ?? '';
                 return (
                   <TableCell key={p} align="center" sx={{ pt: 1.5 }}>
                     <ExecutionStatusCell
@@ -211,46 +268,9 @@ export default function ExecutionMatrix({
                       </Typography>
                     )}
                     {!readOnly && (
-                      <TextField
-                        size="small"
-                        multiline
-                        minRows={1}
-                        maxRows={4}
-                        placeholder="Actual data used…"
-                        value={actualDataUsed}
-                        onChange={(e) => {
-                          // Local optimistic update via parent map — parent handles state
-                          onActualDataChange?.(step.id, p, e.target.value || null);
-                        }}
-                        onBlur={(e) => {
-                          const val = e.target.value;
-                          // Coerce empty string to null before saving (EC-03)
-                          const normalized = val.trim() === '' ? null : val;
-                          if (normalized !== (result?.actual_data_used ?? null)) {
-                            onActualDataChange?.(step.id, p, normalized);
-                          }
-                        }}
-                        sx={{
-                          mt: 0.75,
-                          width: '100%',
-                          '& .MuiInputBase-root': {
-                            fontSize: '0.7rem',
-                            py: 0.5,
-                            bgcolor: alpha(palette.warning.main, 0.06),
-                            border: `1px solid ${alpha(palette.warning.main, 0.25)}`,
-                            borderRadius: '4px',
-                          },
-                          '& textarea': { resize: 'none' },
-                          '& .MuiOutlinedInput-notchedOutline': {
-                            borderColor: alpha(palette.warning.main, 0.3),
-                          },
-                          '&:hover .MuiOutlinedInput-notchedOutline': {
-                            borderColor: palette.warning.main,
-                          },
-                        }}
-                        inputProps={{ maxLength: 10000 }}
-                        label="Actual data used"
-                        InputLabelProps={{ sx: { fontSize: '0.65rem', color: palette.warning.main } }}
+                      <ActualDataField
+                        committed={result?.actual_data_used}
+                        onCommit={(value) => onActualDataChange?.(step.id, p, value)}
                       />
                     )}
                     {readOnly && result?.actual_data_used && (

--- a/src/components/execution/ExecutionMatrix.tsx
+++ b/src/components/execution/ExecutionMatrix.tsx
@@ -21,6 +21,7 @@ export interface ResultEntry {
   status: ExecutionStatus;
   id?: string;
   comment?: string | null;
+  actual_data_used?: string | null;
 }
 
 export interface ResultMap {
@@ -47,6 +48,7 @@ interface ExecutionMatrixProps {
   onBrowserChange?: (browser: string) => void;
   onStatusChange: (stepId: string, platform: Platform, status: ExecutionStatus, comment?: string | null) => void;
   onCommentChange?: (stepId: string, platform: Platform, comment: string) => void;
+  onActualDataChange?: (stepId: string, platform: Platform, value: string | null) => void;
   readOnly?: boolean;
 }
 
@@ -57,7 +59,7 @@ const PLATFORM_LABELS: Record<Platform, string> = {
 };
 
 export default function ExecutionMatrix({
-  steps, platforms, results, browsers, selectedBrowser, onBrowserChange, onStatusChange, onCommentChange, readOnly,
+  steps, platforms, results, browsers, selectedBrowser, onBrowserChange, onStatusChange, onCommentChange, onActualDataChange, readOnly,
 }: ExecutionMatrixProps) {
   return (
     <Box>
@@ -156,7 +158,7 @@ export default function ExecutionMatrix({
                     }}
                   >
                     <Typography variant="caption" sx={{ fontWeight: 600, color: palette.info.main }}>
-                      Test Data:
+                      Expected data:
                     </Typography>
                     <Typography variant="caption" sx={{ color: 'text.primary', ml: 0.5 }}>
                       {step.test_data}
@@ -168,6 +170,7 @@ export default function ExecutionMatrix({
                 const result = results[step.id]?.[p];
                 const status = result?.status ?? 'not_run';
                 const comment = result?.comment ?? '';
+                const actualDataUsed = result?.actual_data_used ?? '';
                 return (
                   <TableCell key={p} align="center" sx={{ pt: 1.5 }}>
                     <ExecutionStatusCell
@@ -206,6 +209,69 @@ export default function ExecutionMatrix({
                       >
                         {comment}
                       </Typography>
+                    )}
+                    {!readOnly && (
+                      <TextField
+                        size="small"
+                        multiline
+                        minRows={1}
+                        maxRows={4}
+                        placeholder="Actual data used…"
+                        value={actualDataUsed}
+                        onChange={(e) => {
+                          // Local optimistic update via parent map — parent handles state
+                          onActualDataChange?.(step.id, p, e.target.value || null);
+                        }}
+                        onBlur={(e) => {
+                          const val = e.target.value;
+                          // Coerce empty string to null before saving (EC-03)
+                          const normalized = val.trim() === '' ? null : val;
+                          if (normalized !== (result?.actual_data_used ?? null)) {
+                            onActualDataChange?.(step.id, p, normalized);
+                          }
+                        }}
+                        sx={{
+                          mt: 0.75,
+                          width: '100%',
+                          '& .MuiInputBase-root': {
+                            fontSize: '0.7rem',
+                            py: 0.5,
+                            bgcolor: alpha(palette.warning.main, 0.06),
+                            border: `1px solid ${alpha(palette.warning.main, 0.25)}`,
+                            borderRadius: '4px',
+                          },
+                          '& textarea': { resize: 'none' },
+                          '& .MuiOutlinedInput-notchedOutline': {
+                            borderColor: alpha(palette.warning.main, 0.3),
+                          },
+                          '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: palette.warning.main,
+                          },
+                        }}
+                        inputProps={{ maxLength: 10000 }}
+                        label="Actual data used"
+                        InputLabelProps={{ sx: { fontSize: '0.65rem', color: palette.warning.main } }}
+                      />
+                    )}
+                    {readOnly && result?.actual_data_used && (
+                      <Box
+                        sx={{
+                          mt: 0.5,
+                          px: 1,
+                          py: 0.25,
+                          borderRadius: '4px',
+                          bgcolor: alpha(palette.warning.main, 0.08),
+                          border: `1px solid ${alpha(palette.warning.main, 0.25)}`,
+                          textAlign: 'left',
+                        }}
+                      >
+                        <Typography variant="caption" sx={{ fontWeight: 600, color: palette.warning.main, display: 'block' }}>
+                          Actual used:
+                        </Typography>
+                        <Typography variant="caption" sx={{ color: 'text.primary' }}>
+                          {result.actual_data_used}
+                        </Typography>
+                      </Box>
                     )}
                   </TableCell>
                 );

--- a/src/lib/validations/execution-result.ts
+++ b/src/lib/validations/execution-result.ts
@@ -10,6 +10,7 @@ export const upsertResultSchema = z.object({
   browser: z.string().trim().max(100).optional().default('default'),
   status: executionStatusEnum,
   comment: z.string().trim().max(2000).nullable().optional(),
+  actual_data_used: z.string().trim().max(10000).nullable().optional(),  // runtime override; never written to test_steps
 });
 
 export const upsertResultsSchema = z.object({

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -154,6 +154,7 @@ export interface ExecutionResult {
   browser: string;
   status: ExecutionStatus;
   comment: string | null;
+  actual_data_used: string | null;   // runtime override; never reflects test_steps.test_data
   executed_by: string | null;
   executed_at: string | null;
   duration_ms: number | null;

--- a/supabase/migrations/00020_execution_result_actual_data_used.sql
+++ b/supabase/migrations/00020_execution_result_actual_data_used.sql
@@ -1,0 +1,5 @@
+-- Migration: add actual_data_used field to execution_results
+-- Allows testers to record the actual test data value used during a step execution.
+-- Scoped to (test_run_id, test_step_id, platform, browser) -- never touches test_steps.
+ALTER TABLE execution_results
+  ADD COLUMN IF NOT EXISTS actual_data_used text DEFAULT NULL;


### PR DESCRIPTION
## Summary

Implements the Runtime Test Data Override feature per ARC doc `0aea6a4a-0f88-4c31-92ca-8409b924e9a5`.

A tester executing a run can now enter the actual test data value they used per step. The value is saved to `execution_results.actual_data_used` — the original test case (`test_steps`) is never touched.

## Changes

### Migration
- `supabase/migrations/00020_execution_result_actual_data_used.sql` — `ALTER TABLE execution_results ADD COLUMN IF NOT EXISTS actual_data_used text DEFAULT NULL` (idempotent, no backfill, no lock)

### Types
- `src/types/database.ts` — `actual_data_used: string | null` added to `ExecutionResult`
- `src/components/execution/ExecutionMatrix.tsx` — `actual_data_used?: string | null` added to `ResultEntry`

### Validation
- `src/lib/validations/execution-result.ts` — `actual_data_used: z.string().trim().max(10000).nullable().optional()` added to `upsertResultSchema`

### API
- `src/app/api/test-runs/[runId]/results/route.ts` — `actual_data_used` included in upsert row mapping; empty string coerced to `null`. Safety comment explicitly notes `test_steps` is never written from this handler.

### Component
- `src/components/execution/ExecutionMatrix.tsx`:
  - Existing `test_data` display relabeled from "Test Data:" → **"Expected data:"** (read-only blue badge, no input)
  - New **"Actual data used"** TextField per platform cell (amber tint, save on blur, empty→null coercion)
  - New `onActualDataChange` callback prop

### Parent Page
- `src/app/(dashboard)/runs/[runId]/execute/[caseId]/page.tsx`:
  - `handleActualDataChange` handler wired to upsert API with optimistic local state update
  - Prefers `snapshot_steps` from `test_run_cases` over live `test_steps` (EC-02 compliance)
  - `actual_data_used` carried through `BrowserResultMap` → `ResultMap` → component

## Safety

- `test_steps` is never written from this path (enforced by schema, Zod, and explicit comment in route)
- Empty string coerced to `null` at both component blur and API boundary
- `DEFAULT NULL` migration — all existing rows unaffected
- Snapshot-first step reading prevents live `test_steps` mutation risk

## Testing Checklist
- [ ] Enter actual data in a step cell — blurring saves to `execution_results`
- [ ] Clear the field — blurring saves `null` (not empty string)
- [ ] Read-only mode: "Actual used:" amber block shown only when non-null
- [ ] "Expected data:" label is read-only, shows original `test_data`
- [ ] Steps with no `test_data`: Expected data block is hidden; Actual data field still renders
- [ ] Run the migration against a local Supabase instance — verify idempotent on second run