### PR TITLE
fix: CSV import Update Files drops steps when parse yields zero steps (#6)

### DIFF
--- a/src/app/api/csv-import/execute/route.ts
+++ b/src/app/api/csv-import/execute/route.ts
@@ -165,18 +165,18 @@ export async function POST(request: Request) {
             continue;
           }
 
-          const { error: deleteErr } = await supabase
-            .from('test_steps')
-            .delete()
-            .eq('test_case_id', existingCase.id);
-
-          if (deleteErr) {
-            errors.push({ row_number: globalIdx + 1, error_message: `Failed to delete old steps for ${tc.display_id}: ${deleteErr.message}` });
-            errorCount++;
-            continue;
-          }
-
           if (tc.steps.length > 0) {
+            const { error: deleteErr } = await supabase
+              .from('test_steps')
+              .delete()
+              .eq('test_case_id', existingCase.id);
+
+            if (deleteErr) {
+              errors.push({ row_number: globalIdx + 1, error_message: `Failed to delete old steps for ${tc.display_id}: ${deleteErr.message}` });
+              errorCount++;
+              continue;
+            }
+
             const { error: stepErr } = await insertSteps(supabase, existingCase.id, tc.steps);
             if (stepErr) {
               errors.push({ row_number: globalIdx + 1, error_message: `Steps deleted but new steps failed for ${tc.display_id}: ${stepErr}` });


### PR DESCRIPTION
## Root Cause

When `duplicate_strategy` is set to **Update Files** (i.e. not `skip`), the update path in `src/app/api/csv-import/execute/route.ts` unconditionally deleted all existing `test_steps` for a matching test case, regardless of how many steps the CSV parser returned for that case:

```ts
// BUG: delete runs even when tc.steps.length === 0
const { error: deleteErr } = await supabase
  .from('test_steps')
  .delete()
  .eq('test_case_id', existingCase.id);

if (tc.steps.length > 0) {
  // insert only happens if steps exist — but delete already wiped them
  await insertSteps(supabase, existingCase.id, tc.steps);
}
```

If the parser yielded 0 steps for a test case (e.g. due to column mapping mismatches or a CSV layout edge case), the old steps were permanently deleted with nothing re-inserted — leaving the test case stepless.

## Fix

Wrapped both the `delete` and `insert` inside `if (tc.steps.length > 0)`. Steps are now only touched during an update if the parser produced at least one step. If the parse yields 0 steps, the existing steps are preserved as-is.

```ts
if (tc.steps.length > 0) {
  // delete only when we have new steps to replace them with
  await supabase.from('test_steps').delete().eq('test_case_id', existingCase.id);
  await insertSteps(supabase, existingCase.id, tc.steps);
}
```

## Parser Edge Case Investigation

Reviewed `src/lib/csv/parse-test-cases.ts` for scenarios where a valid test case could reach the executor with 0 steps:

- **All `testCases.push` calls are guarded by `currentCase.steps.length > 0`** — this means the parser itself will never emit a test case with 0 steps under the current implementation.
- However, this is an implementation detail of the parser, not a contract enforced by the type system. The `ParsedTestCase` type allows `steps: []`. A future parser change or alternative entry point could produce 0-step cases.
- The fix in `execute/route.ts` therefore serves as a necessary **defensive guard** at the executor layer, independent of parser behavior.

## Testing Notes

To reproduce the bug before this fix:
1. Import a CSV with test cases that have steps
2. Re-import the same CSV with the column mapping deliberately shifted so step rows aren't classified (yielding 0 steps per case)
3. Observe that all steps are deleted and not restored

After this fix, step 3 should leave existing steps intact.

Closes #6