### PR TITLE
fix: suppress duplicate Tiptap link extension warning in NoteEditor

### DIFF
--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -42,6 +42,8 @@ export default function NoteEditor({
     extensions: [
       StarterKit.configure({
         heading: { levels: [1, 2, 3] },
+        // Disable StarterKit's built-in link so the explicit LinkExtension below doesn't duplicate
+        link: false,
       }),
       LinkExtension.configure({
         openOnClick: true,


### PR DESCRIPTION
## Problem

Console shows: `[tiptap warn]: Duplicate extension names found: ['link']`

StarterKit includes a built-in `link` extension by default. `NoteEditor` also adds `LinkExtension` explicitly (for custom `HTMLAttributes`, `autolink`, etc). Tiptap detects both and warns about the duplicate.

## Fix

Added `link: false` to `StarterKit.configure()` to disable the built-in one, leaving only the explicitly configured `LinkExtension` active. No behavior change — the explicit extension was already the active one.

One-line change in `src/components/notes/NoteEditor.tsx`.