### PR TITLE
fix: reset didDrag after pointerup so FAB click opens panel

### DIFF
--- a/src/components/notes/QuickNotesFab.tsx
+++ b/src/components/notes/QuickNotesFab.tsx
@@ -112,6 +112,8 @@ export default function QuickNotesFab() {
 
   const handlePointerUp = useCallback(() => {
     dragState.current = null;
+    // Reset after a short delay so the onClick handler can read the value first
+    setTimeout(() => { didDrag.current = false; }, 0);
   }, []);
 
   const resetForm = useCallback(() => {


### PR DESCRIPTION
## Problem

After dragging the FAB, `didDrag.current` was left as `true` and never reset. Every subsequent click was treated as a drag, so `setPanelOpen` was never called — panel wouldn't open after the first drag.

## Fix

Reset `didDrag.current = false` in `handlePointerUp` via `setTimeout(..., 0)` so the FAB's `onClick` handler (which fires synchronously before the timeout) still sees the correct `true` value for that drag, then it resets cleanly for the next interaction.