### PR TITLE
fix: remove invalid ALTER TYPE integration_type from feedback portal migration

### DIFF
--- a/supabase/migrations/00030_feedback_portal.sql
+++ b/supabase/migrations/00030_feedback_portal.sql
@@ -168,8 +168,9 @@ CREATE POLICY feedback_attachments_select_auth ON feedback_attachments
 -- 4. New integration types
 -- ============================================================
 
-ALTER TYPE integration_type ADD VALUE IF NOT EXISTS 'gitlab_issues';
-ALTER TYPE integration_type ADD VALUE IF NOT EXISTS 'ado';
+-- Note: integrations.type is a plain text column (not a Postgres enum).
+-- New values 'gitlab_issues' and 'ado' are handled at the application layer only.
+-- No schema change needed here.
 
 -- ============================================================
 -- 5. Storage bucket: feedback-attachments


### PR DESCRIPTION
## What

Removes two invalid `ALTER TYPE integration_type` statements from migration `00030_feedback_portal.sql`.

## Why

`integrations.type` is a plain `text` column — not a Postgres enum. The `ALTER TYPE` calls caused:
```
ERROR: 42704: type "integration_type" does not exist
```

The new integration types (`gitlab_issues`, `ado`) are handled at the application layer only — no schema change needed.

## Changes
- `supabase/migrations/00030_feedback_portal.sql` — removed 2 `ALTER TYPE` lines, added comment explaining why