### PR TITLE
fix: remove invalid set_config transaction isolation from export snapshot RPCs

### DIFF
--- a/supabase/migrations/00031_fix_export_snapshot_rpcs.sql
+++ b/supabase/migrations/00031_fix_export_snapshot_rpcs.sql
@@ -1,0 +1,116 @@
+-- Fix export snapshot RPCs: remove invalid set_config('transaction_isolation', ...) calls.
+-- STABLE functions cannot change transaction isolation level mid-transaction —
+-- Supabase/PostgREST wraps each request in its own transaction, so snapshot
+-- consistency is already guaranteed without the set_config call.
+-- Removing it eliminates the ERROR: invalid transaction isolation level that
+-- was causing every export to 500.
+
+CREATE OR REPLACE FUNCTION export_project_snapshot(p_project_id uuid)
+RETURNS json AS $$
+DECLARE
+  result json;
+BEGIN
+  SELECT json_build_object(
+    'suites', (
+      SELECT json_agg(suite_data ORDER BY suite_data_position)
+      FROM (
+        SELECT
+          s.position AS suite_data_position,
+          json_build_object(
+            'id', s.id,
+            'name', s.name,
+            'position', s.position,
+            'color_index', s.color_index,
+            'prefix', s.prefix,
+            'test_cases', (
+              SELECT json_agg(tc_data ORDER BY tc_data_position)
+              FROM (
+                SELECT
+                  tc.position AS tc_data_position,
+                  json_build_object(
+                    'id', tc.id,
+                    'display_id', tc.display_id,
+                    'title', tc.title,
+                    'description', tc.description,
+                    'precondition', tc.precondition,
+                    'position', tc.position,
+                    'automation_status', tc.automation_status,
+                    'steps', (
+                      SELECT json_agg(ts ORDER BY ts.step_number)
+                      FROM test_steps ts
+                      WHERE ts.test_case_id = tc.id
+                    ),
+                    'bug_links', (
+                      SELECT json_agg(bl)
+                      FROM bug_links bl
+                      WHERE bl.test_case_id = tc.id
+                    )
+                  ) AS tc_data
+                FROM test_cases tc
+                WHERE tc.suite_id = s.id
+                  AND tc.deleted_at IS NULL
+              ) tc_rows
+            )
+          ) AS suite_data
+        FROM suites s
+        WHERE s.project_id = p_project_id
+      ) suite_rows
+    )
+  ) INTO result;
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = public;
+
+CREATE OR REPLACE FUNCTION export_suite_snapshot(p_suite_id uuid)
+RETURNS json AS $$
+DECLARE
+  result json;
+BEGIN
+  SELECT json_build_object(
+    'suites', json_build_array(
+      json_build_object(
+        'id', s.id,
+        'name', s.name,
+        'position', s.position,
+        'color_index', s.color_index,
+        'prefix', s.prefix,
+        'test_cases', (
+          SELECT json_agg(tc_data ORDER BY tc_data_position)
+          FROM (
+            SELECT
+              tc.position AS tc_data_position,
+              json_build_object(
+                'id', tc.id,
+                'display_id', tc.display_id,
+                'title', tc.title,
+                'description', tc.description,
+                'precondition', tc.precondition,
+                'position', tc.position,
+                'automation_status', tc.automation_status,
+                'steps', (
+                  SELECT json_agg(ts ORDER BY ts.step_number)
+                  FROM test_steps ts
+                  WHERE ts.test_case_id = tc.id
+                ),
+                'bug_links', (
+                  SELECT json_agg(bl)
+                  FROM bug_links bl
+                  WHERE bl.test_case_id = tc.id
+                )
+              ) AS tc_data
+            FROM test_cases tc
+            WHERE tc.suite_id = s.id
+              AND tc.deleted_at IS NULL
+          ) tc_rows
+        )
+      )
+    )
+  )
+  INTO result
+  FROM suites s
+  WHERE s.id = p_suite_id;
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = public;


### PR DESCRIPTION
## Root Cause

The `export_project_snapshot` and `export_suite_snapshot` RPCs call `set_config('transaction_isolation', 'repeatable read', true)` inside a `STABLE` function. Supabase/PostgREST wraps every request in a transaction before the function runs — calling `set_config` mid-transaction to change isolation level throws:

```
ERROR: invalid transaction isolation level
```

This caused every project/suite export to return a 500 immediately after the RPC was called.

## Fix

Migration `00031_fix_export_snapshot_rpcs.sql` replaces both RPCs with identical versions minus the `set_config` call. PostgREST already provides single-transaction consistency per request, so snapshot consistency is preserved without it.

## Impact

- Project export (xlsx + Google Sheets) unblocked
- Suite export (xlsx + Google Sheets) unblocked
- Feedback export was unaffected (different code path — that's why it worked)
- No schema changes, purely a function replacement

## How to unblock (Spencer)

1. Go to Supabase SQL Editor
2. Paste and run `supabase/migrations/00031_fix_export_snapshot_rpcs.sql`
3. Merge this PR + Vercel redeploys automatically

That's it — export should work immediately after step 2.