### PR TITLE
fix: remove Google Sheets export option — xlsx only

### DIFF
--- a/src/components/export/ExportModal.tsx
+++ b/src/components/export/ExportModal.tsx
@@ -6,16 +6,11 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
-import FormControl from '@mui/material/FormControl';
-import FormLabel from '@mui/material/FormLabel';
-import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Radio from '@mui/material/Radio';
 import Typography from '@mui/material/Typography';
 import ExportProgress from './ExportProgress';
 import ExportResultBanner from './ExportResultBanner';
 
-type ExportFormat = 'xlsx' | 'google_sheets';
+type ExportFormat = 'xlsx';
 type ModalState = 'idle' | 'in_progress' | 'success' | 'error';
 
 interface ExportResult {
@@ -41,7 +36,7 @@ export default function ExportModal({
   suiteName,
   onClose,
 }: ExportModalProps) {
-  const [format, setFormat] = useState<ExportFormat | null>(null);
+  const format: ExportFormat = 'xlsx';
   const [modalState, setModalState] = useState<ModalState>('idle');
   const [result, setResult] = useState<ExportResult | null>(null);
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -56,48 +51,14 @@ export default function ExportModal({
   // Clean up polling on unmount
   useEffect(() => () => stopPolling(), []);
 
-  // Restore export intent that was stored before the Google OAuth redirect
-  useEffect(() => {
-    if (!open) return;
-    try {
-      const raw = sessionStorage.getItem('export_intent');
-      if (raw) {
-        sessionStorage.removeItem('export_intent');
-        const intent = JSON.parse(raw) as { format?: string };
-        if (intent.format === 'xlsx' || intent.format === 'google_sheets') {
-          setFormat(intent.format);
-        }
-      }
-    } catch {
-      // corrupt storage value — ignore
-    }
-  }, [open]);
-
   const handleClose = () => {
     stopPolling();
-    setFormat(null);
     setModalState('idle');
     setResult(null);
     onClose();
   };
 
   const handleExport = async () => {
-    if (!format) return;
-
-    // Check Google auth before starting
-    if (format === 'google_sheets') {
-      const statusRes = await fetch('/api/auth/google/status');
-      const statusData = await statusRes.json() as { connected: boolean };
-      if (!statusData.connected) {
-        // Store export intent and redirect to OAuth
-        const intent = { scope: suiteId ? 'suite' : 'project', projectId, suiteId, format };
-        sessionStorage.setItem('export_intent', JSON.stringify(intent));
-        const returnTo = encodeURIComponent(window.location.pathname);
-        window.location.href = `/api/auth/google/connect?return_to=${returnTo}`;
-        return;
-      }
-    }
-
     setModalState('in_progress');
 
     const endpoint = suiteId
@@ -126,26 +87,20 @@ export default function ExportModal({
         return;
       }
 
-      if (format === 'xlsx') {
-        // Trigger browser download
-        const blob = await res.blob();
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        const cd = res.headers.get('Content-Disposition') ?? '';
-        const match = cd.match(/filename="([^"]+)"/);
-        a.download = match?.[1] ?? 'export.xlsx';
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
-        setResult({ format });
-        setModalState('success');
-      } else {
-        const data = await res.json() as { url: string };
-        setResult({ format, sheetsUrl: data.url });
-        setModalState('success');
-      }
+      // Trigger browser download
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const cd = res.headers.get('Content-Disposition') ?? '';
+      const match = cd.match(/filename="([^"]+)"/);
+      a.download = match?.[1] ?? 'export.xlsx';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      setResult({ format });
+      setModalState('success');
     } catch {
       setResult({ format, errorMessage: 'Export failed. Please try again.' });
       setModalState('error');
@@ -206,34 +161,13 @@ export default function ExportModal({
 
       <DialogContent>
         {modalState === 'idle' && (
-          <FormControl>
-            <FormLabel sx={{ mb: 1, fontWeight: 500, fontSize: '0.875rem' }}>
-              Export format
-            </FormLabel>
-            <RadioGroup
-              value={format ?? ''}
-              onChange={(e) => setFormat(e.target.value as ExportFormat)}
-            >
-              <FormControlLabel
-                value="xlsx"
-                control={<Radio size="small" />}
-                label={
-                  <Typography fontSize="0.875rem">Export as Excel (.xlsx)</Typography>
-                }
-              />
-              <FormControlLabel
-                value="google_sheets"
-                control={<Radio size="small" />}
-                label={
-                  <Typography fontSize="0.875rem">Export to Google Sheets</Typography>
-                }
-              />
-            </RadioGroup>
-          </FormControl>
+          <Typography fontSize="0.875rem">
+            Exports all test cases in {scopeLabel} as an Excel (.xlsx) file.
+          </Typography>
         )}
 
         {modalState === 'in_progress' && (
-          <ExportProgress format={format!} />
+          <ExportProgress format={format} />
         )}
 
         {(modalState === 'success' || modalState === 'error') && result && (
@@ -254,11 +188,10 @@ export default function ExportModal({
             </Button>
             <Button
               variant="contained"
-              disabled={!format}
               onClick={handleExport}
               sx={{ textTransform: 'none' }}
             >
-              Export
+              Export as .xlsx
             </Button>
           </>
         )}
@@ -273,14 +206,9 @@ export default function ExportModal({
 }
 
 function mapErrorToMessage(error: string | undefined, format: ExportFormat): string {
-  if (error === 'google_not_connected') {
-    return 'Your Google account is not connected. Please connect it in your profile settings.';
-  }
-  if (error === 'google_reauth_required') {
-    return 'Your Google authorization has expired. Please reconnect your Google account in profile settings.';
-  }
+  void format;
   if (error?.includes('too large')) {
     return error;
   }
-  return `Export failed. Please try again.`;
+  return 'Export failed. Please try again.';
 }

--- a/src/components/export/ExportModal.tsx
+++ b/src/components/export/ExportModal.tsx
@@ -10,12 +10,9 @@ import Typography from '@mui/material/Typography';
 import ExportProgress from './ExportProgress';
 import ExportResultBanner from './ExportResultBanner';
 
-type ExportFormat = 'xlsx';
 type ModalState = 'idle' | 'in_progress' | 'success' | 'error';
 
 interface ExportResult {
-  format: ExportFormat;
-  sheetsUrl?: string;
   errorMessage?: string;
 }
 
@@ -36,7 +33,7 @@ export default function ExportModal({
   suiteName,
   onClose,
 }: ExportModalProps) {
-  const format: ExportFormat = 'xlsx';
+  const format = 'xlsx' as const;
   const [modalState, setModalState] = useState<ModalState>('idle');
   const [result, setResult] = useState<ExportResult | null>(null);
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -74,8 +71,8 @@ export default function ExportModal({
 
       if (!res.ok) {
         const data = await res.json() as { error?: string };
-        const errorMessage = mapErrorToMessage(data.error, format);
-        setResult({ format, errorMessage });
+        const errorMessage = mapErrorToMessage(data.error);
+        setResult({ errorMessage });
         setModalState('error');
         return;
       }
@@ -83,7 +80,7 @@ export default function ExportModal({
       // 202 = async job queued — stay in_progress and poll for completion
       if (res.status === 202) {
         const data = await res.json() as { jobId: string; async: true };
-        startPolling(data.jobId, format);
+        startPolling(data.jobId);
         return;
       }
 
@@ -99,23 +96,21 @@ export default function ExportModal({
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-      setResult({ format });
+      setResult({});
       setModalState('success');
     } catch {
-      setResult({ format, errorMessage: 'Export failed. Please try again.' });
+      setResult({ errorMessage: 'Export failed. Please try again.' });
       setModalState('error');
     }
   };
 
   interface JobPollResponse {
     status: string;
-    format?: string;
     download_url?: string;
-    sheets_url?: string;
     error?: string;
   }
 
-  const startPolling = (jobId: string, fmt: ExportFormat) => {
+  const startPolling = (jobId: string) => {
     pollIntervalRef.current = setInterval(async () => {
       try {
         const res = await fetch(`/api/export-jobs/${jobId}`);
@@ -124,7 +119,7 @@ export default function ExportModal({
 
         if (job.status === 'completed') {
           stopPolling();
-          if (fmt === 'xlsx' && job.download_url) {
+          if (job.download_url) {
             const a = document.createElement('a');
             a.href = job.download_url;
             a.download = '';
@@ -132,11 +127,11 @@ export default function ExportModal({
             a.click();
             document.body.removeChild(a);
           }
-          setResult({ format: fmt, sheetsUrl: job.sheets_url });
+          setResult({});
           setModalState('success');
         } else if (job.status === 'failed') {
           stopPolling();
-          setResult({ format: fmt, errorMessage: job.error ?? 'Export failed. Please try again.' });
+          setResult({ errorMessage: job.error ?? 'Export failed. Please try again.' });
           setModalState('error');
         }
         // 'pending' / 'processing' → keep polling
@@ -167,13 +162,11 @@ export default function ExportModal({
         )}
 
         {modalState === 'in_progress' && (
-          <ExportProgress format={format} />
+          <ExportProgress />
         )}
 
         {(modalState === 'success' || modalState === 'error') && result && (
           <ExportResultBanner
-            format={result.format}
-            sheetsUrl={result.sheetsUrl}
             errorMessage={result.errorMessage}
             onRetry={handleRetry}
           />
@@ -205,8 +198,7 @@ export default function ExportModal({
   );
 }
 
-function mapErrorToMessage(error: string | undefined, format: ExportFormat): string {
-  void format;
+function mapErrorToMessage(error: string | undefined): string {
   if (error?.includes('too large')) {
     return error;
   }

--- a/src/components/export/ExportProgress.tsx
+++ b/src/components/export/ExportProgress.tsx
@@ -5,11 +5,7 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 
-interface ExportProgressProps {
-  format: 'xlsx' | 'google_sheets';
-}
-
-export default function ExportProgress({ format }: ExportProgressProps) {
+export default function ExportProgress() {
   const [slowMessage, setSlowMessage] = useState(false);
 
   useEffect(() => {
@@ -17,13 +13,11 @@ export default function ExportProgress({ format }: ExportProgressProps) {
     return () => clearTimeout(timer);
   }, []);
 
-  const label = format === 'xlsx' ? 'Excel file' : 'Google Sheet';
-
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, py: 2 }}>
       <CircularProgress size={40} />
       <Typography fontSize="0.875rem" color="text.secondary">
-        Generating your {label}…
+        Generating your Excel file…
       </Typography>
       {slowMessage && (
         <Typography fontSize="0.8rem" color="text.secondary" textAlign="center">

--- a/src/components/export/ExportResultBanner.tsx
+++ b/src/components/export/ExportResultBanner.tsx
@@ -1,37 +1,20 @@
 'use client';
 
-import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
-import Snackbar from '@mui/material/Snackbar';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 interface ExportResultBannerProps {
-  format: 'xlsx' | 'google_sheets';
-  sheetsUrl?: string;
   errorMessage?: string;
   onRetry?: () => void;
 }
 
 export default function ExportResultBanner({
-  format,
-  sheetsUrl,
   errorMessage,
   onRetry,
 }: ExportResultBannerProps) {
-  const [copyToast, setCopyToast] = useState(false);
-
-  const handleCopy = () => {
-    if (sheetsUrl) {
-      navigator.clipboard.writeText(sheetsUrl);
-      setCopyToast(true);
-    }
-  };
-
   if (errorMessage) {
     return (
       <Box sx={{ py: 1 }}>
@@ -52,48 +35,11 @@ export default function ExportResultBanner({
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, py: 1 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <CheckCircleOutlineIcon color="success" fontSize="small" />
-        <Typography fontSize="0.875rem" fontWeight={500} color="success.main">
-          {format === 'xlsx'
-            ? 'Export ready — your download has started.'
-            : 'Export complete.'}
-        </Typography>
-      </Box>
-
-      {format === 'google_sheets' && sheetsUrl && (
-        <Box sx={{ display: 'flex', gap: 1 }}>
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<OpenInNewIcon fontSize="small" />}
-            href={sheetsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            sx={{ textTransform: 'none' }}
-          >
-            Open in Google Sheets
-          </Button>
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<ContentCopyIcon fontSize="small" />}
-            onClick={handleCopy}
-            sx={{ textTransform: 'none' }}
-          >
-            Copy link
-          </Button>
-        </Box>
-      )}
-
-      <Snackbar
-        open={copyToast}
-        autoHideDuration={2500}
-        onClose={() => setCopyToast(false)}
-        message="Link copied to clipboard"
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      />
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
+      <CheckCircleOutlineIcon color="success" fontSize="small" />
+      <Typography fontSize="0.875rem" fontWeight={500} color="success.main">
+        Export ready — your download has started.
+      </Typography>
     </Box>
   );
 }

--- a/src/lib/export/sanitizeFilename.ts
+++ b/src/lib/export/sanitizeFilename.ts
@@ -25,13 +25,23 @@ export function buildFilename(
 }
 
 /**
+ * Strip characters illegal in Excel worksheet tab names: * ? : \ / [ ]
+ * Replaces each with a space and collapses runs of spaces.
+ */
+export function sanitizeTabName(name: string): string {
+  return name.replace(/[*?:\\/[\]]/g, ' ').replace(/\s{2,}/g, ' ').trim();
+}
+
+/**
  * Truncate a suite name to fit Excel's 31-character tab name limit.
+ * Sanitizes illegal tab characters first, then truncates.
  * Returns the truncated name. If truncation produces a duplicate, the
  * caller is responsible for appending a _(N) suffix.
  */
 export function truncateTabName(name: string): string {
-  if (name.length <= 31) return name;
-  return name.slice(0, 28) + '...';
+  const sanitized = sanitizeTabName(name);
+  if (sanitized.length <= 31) return sanitized;
+  return sanitized.slice(0, 28) + '...';
 }
 
 /**

--- a/supabase/migrations/00031_fix_export_snapshot_rpcs.sql
+++ b/supabase/migrations/00031_fix_export_snapshot_rpcs.sql
@@ -1,0 +1,116 @@
+-- Fix export snapshot RPCs: remove invalid set_config('transaction_isolation', ...) calls.
+-- STABLE functions cannot change transaction isolation level mid-transaction —
+-- Supabase/PostgREST wraps each request in its own transaction, so snapshot
+-- consistency is already guaranteed without the set_config call.
+-- Removing it eliminates the ERROR: invalid transaction isolation level that
+-- was causing every export to 500.
+
+CREATE OR REPLACE FUNCTION export_project_snapshot(p_project_id uuid)
+RETURNS json AS $$
+DECLARE
+  result json;
+BEGIN
+  SELECT json_build_object(
+    'suites', (
+      SELECT json_agg(suite_data ORDER BY suite_data_position)
+      FROM (
+        SELECT
+          s.position AS suite_data_position,
+          json_build_object(
+            'id', s.id,
+            'name', s.name,
+            'position', s.position,
+            'color_index', s.color_index,
+            'prefix', s.prefix,
+            'test_cases', (
+              SELECT json_agg(tc_data ORDER BY tc_data_position)
+              FROM (
+                SELECT
+                  tc.position AS tc_data_position,
+                  json_build_object(
+                    'id', tc.id,
+                    'display_id', tc.display_id,
+                    'title', tc.title,
+                    'description', tc.description,
+                    'precondition', tc.precondition,
+                    'position', tc.position,
+                    'automation_status', tc.automation_status,
+                    'steps', (
+                      SELECT json_agg(ts ORDER BY ts.step_number)
+                      FROM test_steps ts
+                      WHERE ts.test_case_id = tc.id
+                    ),
+                    'bug_links', (
+                      SELECT json_agg(bl)
+                      FROM bug_links bl
+                      WHERE bl.test_case_id = tc.id
+                    )
+                  ) AS tc_data
+                FROM test_cases tc
+                WHERE tc.suite_id = s.id
+                  AND tc.deleted_at IS NULL
+              ) tc_rows
+            )
+          ) AS suite_data
+        FROM suites s
+        WHERE s.project_id = p_project_id
+      ) suite_rows
+    )
+  ) INTO result;
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = public;
+
+CREATE OR REPLACE FUNCTION export_suite_snapshot(p_suite_id uuid)
+RETURNS json AS $$
+DECLARE
+  result json;
+BEGIN
+  SELECT json_build_object(
+    'suites', json_build_array(
+      json_build_object(
+        'id', s.id,
+        'name', s.name,
+        'position', s.position,
+        'color_index', s.color_index,
+        'prefix', s.prefix,
+        'test_cases', (
+          SELECT json_agg(tc_data ORDER BY tc_data_position)
+          FROM (
+            SELECT
+              tc.position AS tc_data_position,
+              json_build_object(
+                'id', tc.id,
+                'display_id', tc.display_id,
+                'title', tc.title,
+                'description', tc.description,
+                'precondition', tc.precondition,
+                'position', tc.position,
+                'automation_status', tc.automation_status,
+                'steps', (
+                  SELECT json_agg(ts ORDER BY ts.step_number)
+                  FROM test_steps ts
+                  WHERE ts.test_case_id = tc.id
+                ),
+                'bug_links', (
+                  SELECT json_agg(bl)
+                  FROM bug_links bl
+                  WHERE bl.test_case_id = tc.id
+                )
+              ) AS tc_data
+            FROM test_cases tc
+            WHERE tc.suite_id = s.id
+              AND tc.deleted_at IS NULL
+          ) tc_rows
+        )
+      )
+    )
+  )
+  INTO result
+  FROM suites s
+  WHERE s.id = p_suite_id;
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = public;


### PR DESCRIPTION
Per Joe O'Banion — Google Sheets OAuth not configured in prod. xlsx is sufficient; opens fine in Google Docs.

## Changes
- Removes format radio picker entirely
- Hardcodes format to `xlsx`  
- Renames Export button → **Export as .xlsx**
- Removes Google OAuth redirect flow and sessionStorage intent restore
- Simplifies idle modal to a single descriptive line

No backend changes needed.