### PR TITLE
feat: TCM Global Docs Section (Phase 1 — Full Throttle parity)

### DIFF
--- a/src/app/(dashboard)/docs/page.tsx
+++ b/src/app/(dashboard)/docs/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import DocsPage from '@/components/docs/DocsPage';
+import { useDocs } from '@/hooks/useDocs';
+
+function DocsPageInner() {
+  const searchParams = useSearchParams();
+  const docId = searchParams.get('docId');
+
+  const hook = useDocs(docId);
+
+  return (
+    <Box sx={{ height: '100%', overflow: 'hidden' }}>
+      <DocsPage hook={hook} />
+    </Box>
+  );
+}
+
+export default function DocsRoute() {
+  return (
+    <Suspense
+      fallback={
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+          <CircularProgress size={32} />
+        </Box>
+      }
+    >
+      <DocsPageInner />
+    </Suspense>
+  );
+}

--- a/src/app/api/docs/[id]/route.ts
+++ b/src/app/api/docs/[id]/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { withAuth, serverError, notFound } from '@/lib/api/helpers';
+
+// GET /api/docs/[id] — get full doc including content
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await withAuth('read');
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth.ctx;
+
+  const { id } = await params;
+
+  const { data: doc, error } = await supabase
+    .from('docs')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return notFound('Doc');
+    return serverError(error.message);
+  }
+
+  return NextResponse.json({ doc });
+}
+
+// PATCH /api/docs/[id] — update title, content, folder_id, project_id
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await withAuth('write');
+  if (!auth.ok) return auth.response;
+  const { supabase, user } = auth.ctx;
+
+  const { id } = await params;
+  const body = await request.json();
+  const { title, content, folder_id, project_id } = body as {
+    title?: string;
+    content?: string;
+    folder_id?: string | null;
+    project_id?: string | null;
+  };
+
+  const updates: Record<string, unknown> = { updated_by: user.id };
+  if (title !== undefined) updates.title = title;
+  if (content !== undefined) updates.content = content;
+  if ('folder_id' in body) updates.folder_id = folder_id ?? null;
+  if ('project_id' in body) updates.project_id = project_id ?? null;
+
+  const { data: doc, error } = await supabase
+    .from('docs')
+    .update(updates)
+    .eq('id', id)
+    .select('*')
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return notFound('Doc');
+    return serverError(error.message);
+  }
+
+  return NextResponse.json({ doc });
+}
+
+// DELETE /api/docs/[id] — delete a doc
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await withAuth('write');
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth.ctx;
+
+  const { id } = await params;
+
+  const { error } = await supabase
+    .from('docs')
+    .delete()
+    .eq('id', id);
+
+  if (error) return serverError(error.message);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/docs/folders/[id]/route.ts
+++ b/src/app/api/docs/folders/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { withAuth, serverError, notFound } from '@/lib/api/helpers';
+
+// PATCH /api/docs/folders/[id] — rename or re-parent a folder
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await withAuth('write');
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth.ctx;
+
+  const { id } = await params;
+  const body = await request.json();
+  const { name, parent_id, position } = body as {
+    name?: string;
+    parent_id?: string | null;
+    position?: number;
+  };
+
+  const updates: Record<string, unknown> = {};
+  if (name !== undefined) updates.name = name.trim();
+  if ('parent_id' in body) updates.parent_id = parent_id ?? null;
+  if (position !== undefined) updates.position = position;
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+  }
+
+  const { data: folder, error } = await supabase
+    .from('doc_folders')
+    .update(updates)
+    .eq('id', id)
+    .select('*')
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return notFound('Folder');
+    return serverError(error.message);
+  }
+
+  return NextResponse.json({ folder });
+}
+
+// DELETE /api/docs/folders/[id] — delete folder (cascade handled by DB)
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await withAuth('write');
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth.ctx;
+
+  const { id } = await params;
+
+  const { error } = await supabase
+    .from('doc_folders')
+    .delete()
+    .eq('id', id);
+
+  if (error) return serverError(error.message);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/docs/folders/route.ts
+++ b/src/app/api/docs/folders/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { withAuth, serverError } from '@/lib/api/helpers';
+
+// GET /api/docs/folders — list all folders (flat list, client builds tree)
+export async function GET() {
+  const auth = await withAuth('read');
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth.ctx;
+
+  const { data, error } = await supabase
+    .from('doc_folders')
+    .select('*')
+    .order('position', { ascending: true })
+    .order('name', { ascending: true });
+
+  if (error) return serverError(error.message);
+
+  return NextResponse.json({ folders: data ?? [] });
+}
+
+// POST /api/docs/folders — create a folder
+export async function POST(request: Request) {
+  const auth = await withAuth('write');
+  if (!auth.ok) return auth.response;
+  const { supabase, user } = auth.ctx;
+
+  const body = await request.json();
+  const { name, parent_id, project_id } = body as {
+    name: string;
+    parent_id?: string;
+    project_id?: string;
+  };
+
+  if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  }
+
+  // Determine position: max sibling position + 1000
+  const { data: siblings } = await supabase
+    .from('doc_folders')
+    .select('position')
+    .eq('parent_id', parent_id ?? null);
+
+  const maxPos = siblings && siblings.length > 0
+    ? Math.max(...siblings.map((s: { position: number }) => s.position))
+    : -1000;
+  const position = maxPos + 1000;
+
+  const { data: folder, error } = await supabase
+    .from('doc_folders')
+    .insert({
+      name: name.trim(),
+      parent_id: parent_id ?? null,
+      project_id: project_id ?? null,
+      position,
+      created_by: user.id,
+    })
+    .select('*')
+    .single();
+
+  if (error) return serverError(error.message);
+
+  return NextResponse.json({ folder }, { status: 201 });
+}

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { withAuth, serverError } from '@/lib/api/helpers';
+
+// GET /api/docs — list docs (summary, no content), optional ?folderId=
+export async function GET(request: Request) {
+  const auth = await withAuth('read');
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth.ctx;
+
+  const { searchParams } = new URL(request.url);
+  const folderId = searchParams.get('folderId');
+
+  let query = supabase
+    .from('docs')
+    .select('id, title, folder_id, project_id, created_by, updated_by, created_at, updated_at')
+    .order('updated_at', { ascending: false });
+
+  if (folderId) {
+    query = query.eq('folder_id', folderId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) return serverError(error.message);
+
+  return NextResponse.json({ docs: data ?? [] });
+}
+
+// POST /api/docs — create a doc
+export async function POST(request: Request) {
+  const auth = await withAuth('write');
+  if (!auth.ok) return auth.response;
+  const { supabase, user } = auth.ctx;
+
+  const body = await request.json();
+  const { title, folder_id, project_id } = body as {
+    title?: string;
+    folder_id?: string;
+    project_id?: string;
+  };
+
+  const { data: doc, error } = await supabase
+    .from('docs')
+    .insert({
+      title: title ?? 'Untitled Document',
+      folder_id: folder_id ?? null,
+      project_id: project_id ?? null,
+      created_by: user.id,
+      updated_by: user.id,
+    })
+    .select('*')
+    .single();
+
+  if (error) return serverError(error.message);
+
+  return NextResponse.json({ doc }, { status: 201 });
+}

--- a/src/components/docs/DocEditor.tsx
+++ b/src/components/docs/DocEditor.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Chip from '@mui/material/Chip';
+import LinkIcon from '@mui/icons-material/Link';
+import CheckIcon from '@mui/icons-material/Check';
+import NoteEditor from '@/components/notes/NoteEditor';
+import type { Doc } from '@/types/database';
+import type { UseDocsReturn } from '@/hooks/useDocs';
+import { useAuth } from '@/components/providers/AuthProvider';
+
+interface DocEditorProps {
+  doc: Doc;
+  saveStatus: UseDocsReturn['saveStatus'];
+  onContentChange: UseDocsReturn['saveDocContent'];
+  onTitleChange: UseDocsReturn['saveDocTitle'];
+}
+
+export default function DocEditor({ doc, saveStatus, onContentChange, onTitleChange }: DocEditorProps) {
+  const { can } = useAuth();
+  const canWrite = can('write');
+
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleValue, setTitleValue] = useState(doc.title);
+  const [copied, setCopied] = useState(false);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  // Sync title when doc changes
+  useEffect(() => {
+    setTitleValue(doc.title);
+  }, [doc.id, doc.title]);
+
+  const handleTitleBlur = async () => {
+    setEditingTitle(false);
+    const trimmed = titleValue.trim();
+    if (trimmed && trimmed !== doc.title) {
+      await onTitleChange(trimmed);
+    } else {
+      setTitleValue(doc.title);
+    }
+  };
+
+  const handleTitleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') titleInputRef.current?.blur();
+    if (e.key === 'Escape') {
+      setTitleValue(doc.title);
+      setEditingTitle(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    const url = `${window.location.origin}/docs?docId=${doc.id}`;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const saveLabel = saveStatus === 'saving'
+    ? 'Saving…'
+    : saveStatus === 'saved'
+      ? 'Saved'
+      : saveStatus === 'error'
+        ? 'Save failed'
+        : null;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      {/* Editor header */}
+      <Box sx={{
+        display: 'flex',
+        alignItems: 'center',
+        px: 3,
+        py: 1.5,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        gap: 1,
+        flexShrink: 0,
+      }}>
+        {/* Title */}
+        {editingTitle && canWrite ? (
+          <TextField
+            inputRef={titleInputRef}
+            value={titleValue}
+            onChange={(e) => setTitleValue(e.target.value)}
+            onBlur={handleTitleBlur}
+            onKeyDown={handleTitleKeyDown}
+            autoFocus
+            size="small"
+            variant="standard"
+            sx={{ flex: 1 }}
+            inputProps={{ style: { fontSize: '1rem', fontWeight: 600 } }}
+          />
+        ) : (
+          <Typography
+            variant="h6"
+            sx={{
+              flex: 1,
+              fontSize: '1rem',
+              fontWeight: 600,
+              cursor: canWrite ? 'text' : 'default',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+            onClick={() => canWrite && setEditingTitle(true)}
+          >
+            {doc.title}
+          </Typography>
+        )}
+
+        {/* Metadata row */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
+          {saveLabel && (
+            <Typography variant="caption" color={saveStatus === 'error' ? 'error.main' : 'text.secondary'}>
+              {saveLabel}
+            </Typography>
+          )}
+
+          <Typography variant="caption" color="text.disabled">
+            Updated {new Date(doc.updated_at).toLocaleDateString()}
+          </Typography>
+
+          {doc.project_id && (
+            <Chip label="Project" size="small" sx={{ height: 20, fontSize: '0.65rem' }} />
+          )}
+
+          <Tooltip title={copied ? 'Copied!' : 'Copy link'}>
+            <IconButton size="small" onClick={handleCopyLink}>
+              {copied ? <CheckIcon sx={{ fontSize: 16, color: 'success.main' }} /> : <LinkIcon sx={{ fontSize: 16 }} />}
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </Box>
+
+      {/* Editor body */}
+      <Box sx={{ flex: 1, overflow: 'auto', px: 3, py: 2 }}>
+        <NoteEditor
+          key={doc.id}
+          content={doc.content ?? ''}
+          onChange={(html) => onContentChange(html)}
+          readOnly={!canWrite}
+          placeholder="Start writing your document…"
+          minHeight={400}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/docs/DocList.tsx
+++ b/src/components/docs/DocList.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import type { DocSummary } from '@/types/database';
+import type { UseDocsReturn } from '@/hooks/useDocs';
+import { useAuth } from '@/components/providers/AuthProvider';
+
+interface DocListProps {
+  docs: DocSummary[];
+  selectedDocId: string | null;
+  selectedFolderId: string | null;
+  onSelectDoc: UseDocsReturn['selectDoc'];
+  onCreateDoc: UseDocsReturn['createDoc'];
+  onDeleteDoc: UseDocsReturn['deleteDoc'];
+  onOpenMoveModal: (docId: string) => void;
+}
+
+export default function DocList({
+  docs,
+  selectedDocId,
+  selectedFolderId,
+  onSelectDoc,
+  onCreateDoc,
+  onDeleteDoc,
+  onOpenMoveModal,
+}: DocListProps) {
+  const { can } = useAuth();
+  const canWrite = can('write');
+
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [menuDocId, setMenuDocId] = useState<string | null>(null);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+
+  const openMenu = (e: React.MouseEvent<HTMLElement>, docId: string) => {
+    e.stopPropagation();
+    setMenuAnchor(e.currentTarget);
+    setMenuDocId(docId);
+  };
+
+  const closeMenu = () => {
+    setMenuAnchor(null);
+    setMenuDocId(null);
+  };
+
+  const handleCopyLink = (docId: string) => {
+    const url = `${window.location.origin}/docs?docId=${docId}`;
+    void navigator.clipboard.writeText(url);
+    closeMenu();
+  };
+
+  const handleMoveDoc = (docId: string) => {
+    closeMenu();
+    onOpenMoveModal(docId);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteConfirmId) return;
+    await onDeleteDoc(deleteConfirmId);
+    setDeleteConfirmId(null);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider', flexShrink: 0 }}>
+        <Typography variant="body2" sx={{ fontWeight: 600, flex: 1, color: 'text.secondary', fontSize: '0.75rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          {selectedFolderId ? 'Documents' : 'All Documents'}
+        </Typography>
+        {canWrite && (
+          <Tooltip title="New document">
+            <IconButton size="small" onClick={() => onCreateDoc(selectedFolderId)}>
+              <AddIcon sx={{ fontSize: 18 }} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
+
+      {/* Doc list */}
+      <Box sx={{ flex: 1, overflow: 'auto' }}>
+        {docs.length === 0 ? (
+          <Box sx={{ px: 2, py: 4, textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              No documents yet
+            </Typography>
+            {canWrite && (
+              <Typography variant="caption" color="text.secondary">
+                Click + to create one
+              </Typography>
+            )}
+          </Box>
+        ) : (
+          <List disablePadding>
+            {docs.map((doc) => (
+              <ListItemButton
+                key={doc.id}
+                selected={selectedDocId === doc.id}
+                onClick={() => onSelectDoc(doc.id)}
+                sx={{
+                  px: 2,
+                  py: 1,
+                  borderBottom: '1px solid',
+                  borderColor: 'divider',
+                  '&:hover .doc-actions': { opacity: 1 },
+                  alignItems: 'flex-start',
+                }}
+              >
+                <ListItemText
+                  primary={doc.title}
+                  secondary={new Date(doc.updated_at).toLocaleDateString()}
+                  primaryTypographyProps={{
+                    fontSize: '0.8125rem',
+                    fontWeight: selectedDocId === doc.id ? 600 : 400,
+                    noWrap: true,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                  secondaryTypographyProps={{ fontSize: '0.7rem' }}
+                />
+                <Box
+                  className="doc-actions"
+                  onClick={(e) => e.stopPropagation()}
+                  sx={{ display: 'flex', alignItems: 'center', opacity: 0, transition: 'opacity 0.15s', flexShrink: 0, ml: 0.5 }}
+                >
+                  <Tooltip title="More actions">
+                    <IconButton size="small" onClick={(e) => openMenu(e, doc.id)} sx={{ p: 0.25 }}>
+                      <MoreVertIcon sx={{ fontSize: 16 }} />
+                    </IconButton>
+                  </Tooltip>
+                  {canWrite && (
+                    <Tooltip title="Delete">
+                      <IconButton
+                        size="small"
+                        sx={{ p: 0.25, color: 'error.main' }}
+                        onClick={(e) => { e.stopPropagation(); setDeleteConfirmId(doc.id); }}
+                      >
+                        <DeleteOutlineIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Box>
+              </ListItemButton>
+            ))}
+          </List>
+        )}
+      </Box>
+
+      {/* Context menu */}
+      <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
+        <MenuItem onClick={() => menuDocId && handleCopyLink(menuDocId)}>Copy link</MenuItem>
+        {canWrite && (
+          <MenuItem onClick={() => menuDocId && handleMoveDoc(menuDocId)}>Move to…</MenuItem>
+        )}
+      </Menu>
+
+      {/* Delete confirm */}
+      <Dialog open={!!deleteConfirmId} onClose={() => setDeleteConfirmId(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete Document</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to permanently delete this document? This cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirmId(null)}>Cancel</Button>
+          <Button variant="contained" color="error" onClick={handleDeleteConfirm}>Delete</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/components/docs/DocsPage.tsx
+++ b/src/components/docs/DocsPage.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import FolderTree from './FolderTree';
+import DocList from './DocList';
+import DocEditor from './DocEditor';
+import MoveDocModal from './MoveDocModal';
+import type { UseDocsReturn } from '@/hooks/useDocs';
+
+interface DocsPageProps {
+  hook: UseDocsReturn;
+}
+
+export default function DocsPage({ hook }: DocsPageProps) {
+  const {
+    folders,
+    docs,
+    selectedFolderId,
+    selectedDocId,
+    selectedDoc,
+    saveStatus,
+    selectFolder,
+    selectDoc,
+    createFolder,
+    renameFolder,
+    deleteFolder,
+    moveFolder,
+    reorderFolders,
+    createDoc,
+    deleteDoc,
+    moveDoc,
+    saveDocContent,
+    saveDocTitle,
+  } = hook;
+
+  const [moveModalDocId, setMoveModalDocId] = useState<string | null>(null);
+
+  // Build doc count per folder for delete warnings
+  const docCountByFolder: Record<string, number> = {};
+  for (const doc of docs) {
+    if (doc.folder_id) {
+      docCountByFolder[doc.folder_id] = (docCountByFolder[doc.folder_id] ?? 0) + 1;
+    }
+  }
+
+  return (
+    <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+      {/* Column 1: Folder tree (240px) */}
+      <Box
+        sx={{
+          width: 240,
+          minWidth: 240,
+          borderRight: '1px solid',
+          borderColor: 'divider',
+          overflow: 'auto',
+          p: 1,
+          flexShrink: 0,
+        }}
+      >
+        <FolderTree
+          folders={folders}
+          selectedFolderId={selectedFolderId}
+          onSelectFolder={selectFolder}
+          onCreateFolder={createFolder}
+          onRenameFolder={renameFolder}
+          onDeleteFolder={deleteFolder}
+          onMoveFolder={moveFolder}
+          onReorderFolders={reorderFolders}
+          docCountByFolder={docCountByFolder}
+        />
+      </Box>
+
+      {/* Column 2: Doc list (280px) */}
+      <Box
+        sx={{
+          width: 280,
+          minWidth: 280,
+          borderRight: '1px solid',
+          borderColor: 'divider',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          flexShrink: 0,
+        }}
+      >
+        <DocList
+          docs={docs}
+          selectedDocId={selectedDocId}
+          selectedFolderId={selectedFolderId}
+          onSelectDoc={selectDoc}
+          onCreateDoc={createDoc}
+          onDeleteDoc={deleteDoc}
+          onOpenMoveModal={(docId) => setMoveModalDocId(docId)}
+        />
+      </Box>
+
+      {/* Column 3: Doc editor (flex) */}
+      <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+        {selectedDoc ? (
+          <DocEditor
+            doc={selectedDoc}
+            saveStatus={saveStatus}
+            onContentChange={saveDocContent}
+            onTitleChange={saveDocTitle}
+          />
+        ) : (
+          <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              Select a document to start editing
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      {/* Move doc modal */}
+      {moveModalDocId && (
+        <MoveDocModal
+          open
+          folders={folders}
+          currentFolderId={docs.find((d) => d.id === moveModalDocId)?.folder_id ?? null}
+          onClose={() => setMoveModalDocId(null)}
+          onMove={(folderId) => {
+            void moveDoc(moveModalDocId, folderId);
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/src/components/docs/FolderTree.tsx
+++ b/src/components/docs/FolderTree.tsx
@@ -1,0 +1,427 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
+import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
+import AddIcon from '@mui/icons-material/Add';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { DocFolder } from '@/types/database';
+import type { UseDocsReturn } from '@/hooks/useDocs';
+import { useAuth } from '@/components/providers/AuthProvider';
+
+interface FolderTreeProps {
+  folders: DocFolder[];
+  selectedFolderId: string | null;
+  onSelectFolder: UseDocsReturn['selectFolder'];
+  onCreateFolder: UseDocsReturn['createFolder'];
+  onRenameFolder: UseDocsReturn['renameFolder'];
+  onDeleteFolder: UseDocsReturn['deleteFolder'];
+  onMoveFolder: UseDocsReturn['moveFolder'];
+  onReorderFolders: UseDocsReturn['reorderFolders'];
+  /** Doc counts per folder for delete warnings */
+  docCountByFolder?: Record<string, number>;
+}
+
+interface SortableFolderItemProps {
+  folder: DocFolder;
+  depth: number;
+  isSelected: boolean;
+  isExpanded: boolean;
+  hasChildren: boolean;
+  canWrite: boolean;
+  canDelete: boolean;
+  onSelect: () => void;
+  onToggle: () => void;
+  onRename: (id: string) => void;
+  onDelete: (id: string) => void;
+  onAddChild: (parentId: string) => void;
+  children?: React.ReactNode;
+}
+
+function SortableFolderItem({
+  folder,
+  depth,
+  isSelected,
+  isExpanded,
+  hasChildren,
+  canWrite,
+  canDelete,
+  onSelect,
+  onToggle,
+  onRename,
+  onDelete,
+  onAddChild,
+  children,
+}: SortableFolderItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: folder.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <Box ref={setNodeRef} style={style} {...attributes}>
+      <ListItemButton
+        {...listeners}
+        selected={isSelected}
+        onClick={onSelect}
+        sx={{
+          pl: 1 + depth * 1.5,
+          pr: 1,
+          py: 0.5,
+          minHeight: 36,
+          borderRadius: '6px',
+          mb: 0.25,
+          '&:hover .folder-actions': { opacity: 1 },
+        }}
+      >
+        <ListItemIcon sx={{ minWidth: 24 }} onClick={(e) => { e.stopPropagation(); onToggle(); }}>
+          {hasChildren
+            ? isExpanded
+              ? <ExpandMoreIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+              : <ChevronRightIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            : <Box sx={{ width: 16 }} />
+          }
+        </ListItemIcon>
+        <ListItemIcon sx={{ minWidth: 28 }}>
+          {isExpanded && hasChildren
+            ? <FolderOpenOutlinedIcon sx={{ fontSize: 18, color: isSelected ? 'primary.main' : 'text.secondary' }} />
+            : <FolderOutlinedIcon sx={{ fontSize: 18, color: isSelected ? 'primary.main' : 'text.secondary' }} />
+          }
+        </ListItemIcon>
+        <ListItemText
+          primary={folder.name}
+          primaryTypographyProps={{
+            fontSize: '0.8125rem',
+            fontWeight: isSelected ? 600 : 400,
+            noWrap: true,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        />
+        <Box
+          className="folder-actions"
+          onClick={(e) => e.stopPropagation()}
+          sx={{ display: 'flex', opacity: 0, transition: 'opacity 0.15s' }}
+        >
+          {canWrite && (
+            <Tooltip title="New subfolder">
+              <IconButton size="small" onClick={() => onAddChild(folder.id)} sx={{ p: 0.25 }}>
+                <AddIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Tooltip>
+          )}
+          {canDelete && (
+            <Tooltip title="Rename">
+              <IconButton size="small" onClick={() => onRename(folder.id)} sx={{ p: 0.25 }}>
+                <EditOutlinedIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Tooltip>
+          )}
+          {canDelete && (
+            <Tooltip title="Delete">
+              <IconButton size="small" onClick={() => onDelete(folder.id)} sx={{ p: 0.25, color: 'error.main' }}>
+                <DeleteOutlineIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
+      </ListItemButton>
+      {isExpanded && children}
+    </Box>
+  );
+}
+
+// Build a tree helper
+function buildChildMap(folders: DocFolder[]): Map<string | null, DocFolder[]> {
+  const map = new Map<string | null, DocFolder[]>();
+  for (const f of folders) {
+    const key = f.parent_id ?? null;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(f);
+  }
+  // Sort by position within each group
+  for (const [, children] of map) {
+    children.sort((a, b) => a.position - b.position || a.name.localeCompare(b.name));
+  }
+  return map;
+}
+
+export default function FolderTree({
+  folders,
+  selectedFolderId,
+  onSelectFolder,
+  onCreateFolder,
+  onRenameFolder,
+  onDeleteFolder,
+  onMoveFolder,
+  onReorderFolders,
+  docCountByFolder = {},
+}: FolderTreeProps) {
+  const { can } = useAuth();
+  const canWrite = can('write');
+  const canDelete = can('write'); // Admin/SDET — delete/rename gated by RLS anyway
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [newFolderParent, setNewFolderParent] = useState<string | null | undefined>(undefined);
+  const [newFolderName, setNewFolderName] = useState('');
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+
+  const toggleExpanded = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleCreateFolder = async () => {
+    if (!newFolderName.trim()) return;
+    await onCreateFolder(newFolderName.trim(), newFolderParent ?? null);
+    setNewFolderName('');
+    setNewFolderParent(undefined);
+    if (newFolderParent) setExpanded((prev) => new Set(prev).add(newFolderParent));
+  };
+
+  const handleRenameConfirm = async () => {
+    if (!renamingId || !renameValue.trim()) return;
+    await onRenameFolder(renamingId, renameValue.trim());
+    setRenamingId(null);
+    setRenameValue('');
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteId) return;
+    await onDeleteFolder(deleteId);
+    setDeleteId(null);
+  };
+
+  // Drag-and-drop: only handles siblings at same parent level
+  const handleDragEnd = useCallback(async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const activeFolder = folders.find((f) => f.id === active.id);
+    const overFolder = folders.find((f) => f.id === over.id);
+    if (!activeFolder || !overFolder) return;
+
+    // Only reorder within same parent
+    if (activeFolder.parent_id !== overFolder.parent_id) return;
+
+    const siblings = folders
+      .filter((f) => f.parent_id === activeFolder.parent_id)
+      .sort((a, b) => a.position - b.position);
+
+    const activeIdx = siblings.findIndex((f) => f.id === active.id);
+    const overIdx = siblings.findIndex((f) => f.id === over.id);
+    if (activeIdx === -1 || overIdx === -1) return;
+
+    // Reorder array
+    const reordered = [...siblings];
+    const [moved] = reordered.splice(activeIdx, 1);
+    reordered.splice(overIdx, 0, moved);
+
+    // Calculate new position using gap algorithm
+    const prevPos = overIdx > 0 ? reordered[overIdx - 1]?.position ?? 0 : 0;
+    const nextPos = reordered[overIdx + 1]?.position;
+    let newPosition: number;
+
+    if (nextPos === undefined) {
+      newPosition = prevPos + 1000;
+    } else {
+      newPosition = Math.floor((prevPos + nextPos) / 2);
+    }
+
+    const gap = nextPos !== undefined ? nextPos - newPosition : 1000;
+
+    if (gap < 10) {
+      // Re-number all siblings
+      await onReorderFolders(reordered);
+    } else {
+      await onMoveFolder(activeFolder.id, activeFolder.parent_id, newPosition);
+    }
+  }, [folders, onMoveFolder, onReorderFolders]);
+
+  const childMap = buildChildMap(folders);
+
+  const renderFolder = (folder: DocFolder, depth: number): React.ReactNode => {
+    const children = childMap.get(folder.id) ?? [];
+    const hasChildren = children.length > 0;
+    const isExpanded = expanded.has(folder.id);
+    const isSelected = selectedFolderId === folder.id;
+
+    return (
+      <SortableFolderItem
+        key={folder.id}
+        folder={folder}
+        depth={depth}
+        isSelected={isSelected}
+        isExpanded={isExpanded}
+        hasChildren={hasChildren}
+        canWrite={canWrite}
+        canDelete={canDelete}
+        onSelect={() => onSelectFolder(folder.id)}
+        onToggle={() => toggleExpanded(folder.id)}
+        onRename={(id) => {
+          setRenamingId(id);
+          setRenameValue(folders.find((f) => f.id === id)?.name ?? '');
+        }}
+        onDelete={(id) => setDeleteId(id)}
+        onAddChild={(parentId) => {
+          setNewFolderParent(parentId);
+          setNewFolderName('');
+        }}
+      >
+        <List disablePadding>
+          <SortableContext items={children.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+            {children.map((child) => renderFolder(child, depth + 1))}
+          </SortableContext>
+        </List>
+      </SortableFolderItem>
+    );
+  };
+
+  const rootFolders = childMap.get(null) ?? [];
+
+  return (
+    <Box>
+      {/* All Docs */}
+      <ListItemButton
+        selected={selectedFolderId === null}
+        onClick={() => onSelectFolder(null)}
+        sx={{ pl: 1.5, py: 0.5, borderRadius: '6px', mb: 0.5 }}
+      >
+        <ListItemIcon sx={{ minWidth: 28 }}>
+          <FolderOpenOutlinedIcon sx={{ fontSize: 18, color: selectedFolderId === null ? 'primary.main' : 'text.secondary' }} />
+        </ListItemIcon>
+        <ListItemText
+          primary="All Docs"
+          primaryTypographyProps={{ fontSize: '0.8125rem', fontWeight: selectedFolderId === null ? 600 : 400 }}
+        />
+      </ListItemButton>
+
+      {/* Folder header + add root folder */}
+      <Box sx={{ display: 'flex', alignItems: 'center', px: 1.5, pt: 1, pb: 0.5 }}>
+        <Typography variant="caption" sx={{ fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary', flex: 1 }}>
+          Folders
+        </Typography>
+        {canWrite && (
+          <Tooltip title="New root folder">
+            <IconButton size="small" onClick={() => { setNewFolderParent(null); setNewFolderName(''); }} sx={{ p: 0.25 }}>
+              <AddIcon sx={{ fontSize: 16 }} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
+
+      {/* Folder tree with DnD */}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={rootFolders.map((f) => f.id)} strategy={verticalListSortingStrategy}>
+          <List disablePadding>
+            {rootFolders.map((folder) => renderFolder(folder, 0))}
+          </List>
+        </SortableContext>
+      </DndContext>
+
+      {/* New folder inline input */}
+      {newFolderParent !== undefined && (
+        <Box sx={{ px: 1.5, pt: 1 }}>
+          <TextField
+            size="small"
+            fullWidth
+            autoFocus
+            placeholder="Folder name"
+            value={newFolderName}
+            onChange={(e) => setNewFolderName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleCreateFolder();
+              if (e.key === 'Escape') setNewFolderParent(undefined);
+            }}
+            onBlur={() => {
+              if (newFolderName.trim()) handleCreateFolder();
+              else setNewFolderParent(undefined);
+            }}
+            inputProps={{ style: { fontSize: '0.8125rem' } }}
+          />
+        </Box>
+      )}
+
+      {/* Rename dialog */}
+      <Dialog open={!!renamingId} onClose={() => setRenamingId(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Rename Folder</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleRenameConfirm(); }}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRenamingId(null)}>Cancel</Button>
+          <Button variant="contained" onClick={handleRenameConfirm}>Rename</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirm dialog */}
+      <Dialog open={!!deleteId} onClose={() => setDeleteId(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Delete Folder</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {deleteId && docCountByFolder[deleteId]
+              ? `This folder contains ${docCountByFolder[deleteId]} document(s). Deleting it will permanently remove all documents.`
+              : 'Are you sure you want to delete this folder? This action cannot be undone.'}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteId(null)}>Cancel</Button>
+          <Button variant="contained" color="error" onClick={handleDeleteConfirm}>Delete</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/components/docs/MoveDocModal.tsx
+++ b/src/components/docs/MoveDocModal.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
+import InboxOutlinedIcon from '@mui/icons-material/InboxOutlined';
+import type { DocFolder } from '@/types/database';
+
+interface MoveDocModalProps {
+  open: boolean;
+  folders: DocFolder[];
+  currentFolderId: string | null;
+  onClose: () => void;
+  onMove: (folderId: string | null) => void;
+}
+
+// Flatten folder tree for picker (indented by depth)
+function flattenFolders(
+  folders: DocFolder[],
+  parentId: string | null = null,
+  depth = 0,
+): Array<{ folder: DocFolder; depth: number }> {
+  const children = folders
+    .filter((f) => f.parent_id === parentId)
+    .sort((a, b) => a.position - b.position || a.name.localeCompare(b.name));
+  return children.flatMap((f) => [
+    { folder: f, depth },
+    ...flattenFolders(folders, f.id, depth + 1),
+  ]);
+}
+
+export default function MoveDocModal({
+  open,
+  folders,
+  currentFolderId,
+  onClose,
+  onMove,
+}: MoveDocModalProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(currentFolderId);
+  const flattened = flattenFolders(folders);
+
+  const handleConfirm = () => {
+    onMove(selectedId);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Move Document</DialogTitle>
+      <DialogContent dividers sx={{ p: 0 }}>
+        <List disablePadding>
+          {/* No folder option */}
+          <ListItemButton
+            selected={selectedId === null}
+            onClick={() => setSelectedId(null)}
+            sx={{ pl: 2 }}
+          >
+            <ListItemIcon sx={{ minWidth: 28 }}>
+              <InboxOutlinedIcon sx={{ fontSize: 18 }} />
+            </ListItemIcon>
+            <ListItemText
+              primary="No folder (root)"
+              primaryTypographyProps={{ fontSize: '0.8125rem' }}
+            />
+          </ListItemButton>
+
+          {flattened.map(({ folder, depth }) => (
+            <ListItemButton
+              key={folder.id}
+              selected={selectedId === folder.id}
+              onClick={() => setSelectedId(folder.id)}
+              sx={{ pl: 2 + depth * 1.5 }}
+            >
+              <ListItemIcon sx={{ minWidth: 28 }}>
+                <FolderOutlinedIcon sx={{ fontSize: 18 }} />
+              </ListItemIcon>
+              <ListItemText
+                primary={folder.name}
+                primaryTypographyProps={{ fontSize: '0.8125rem' }}
+              />
+            </ListItemButton>
+          ))}
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleConfirm}
+          disabled={selectedId === currentFolderId}
+        >
+          Move
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -45,7 +45,7 @@ interface NavItem {
   icon: React.ReactNode;
   disabled?: boolean;
   adminOnly?: boolean;
-  permission?: 'view_webhooks' | 'soft_delete' | 'view_feedback';
+  permission?: 'view_webhooks' | 'soft_delete' | 'view_feedback' | 'docs:read';
 }
 
 const NAV_ITEMS: NavItem[] = [
@@ -53,6 +53,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Projects', href: '/projects', icon: <FolderOutlinedIcon /> },
   { label: 'Test Runs', href: '/runs', icon: <PlaylistPlayIcon /> },
   { label: 'Reports', href: '/reports', icon: <AssessmentOutlinedIcon /> },
+  { label: 'Docs', href: '/docs', icon: <MenuBookOutlinedIcon /> },
   { label: 'Feedback', href: '/feedback-inbox', icon: <InboxOutlinedIcon />, permission: 'view_feedback' as const },
   { label: 'Integrations', href: '/integrations', icon: <WebhookOutlinedIcon />, permission: 'view_webhooks' },
   { label: 'Users', href: '/users', icon: <PeopleOutlineIcon />, adminOnly: true },

--- a/src/hooks/useDocs.ts
+++ b/src/hooks/useDocs.ts
@@ -1,0 +1,353 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { DocFolder, DocSummary, Doc } from '@/types/database';
+
+export type SaveStatus = 'saved' | 'saving' | 'error' | null;
+
+export interface UseDocsReturn {
+  folders: DocFolder[];
+  docs: DocSummary[];
+  selectedFolderId: string | null;
+  selectedDocId: string | null;
+  selectedDoc: Doc | null;
+  projectFilter: string | null;
+  isSaving: boolean;
+  saveStatus: SaveStatus;
+  // Actions
+  selectFolder: (folderId: string | null) => void;
+  selectDoc: (docId: string | null) => void;
+  setProjectFilter: (projectId: string | null) => void;
+  createFolder: (name: string, parentId?: string | null, projectId?: string | null) => Promise<DocFolder | null>;
+  renameFolder: (id: string, name: string) => Promise<void>;
+  deleteFolder: (id: string) => Promise<void>;
+  moveFolder: (id: string, parentId: string | null, position: number) => Promise<void>;
+  reorderFolders: (siblings: DocFolder[]) => Promise<void>;
+  createDoc: (folderId?: string | null) => Promise<Doc | null>;
+  deleteDoc: (id: string) => Promise<void>;
+  moveDoc: (docId: string, folderId: string | null) => Promise<void>;
+  saveDocContent: (content: string) => void;
+  saveDocTitle: (title: string) => Promise<void>;
+  refreshFolders: () => Promise<void>;
+  refreshDocs: (folderId?: string | null) => Promise<void>;
+}
+
+const AUTOSAVE_DELAY = 1500;
+
+export function useDocs(initialDocId?: string | null): UseDocsReturn {
+  const [folders, setFolders] = useState<DocFolder[]>([]);
+  const [docs, setDocs] = useState<DocSummary[]>([]);
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(initialDocId ?? null);
+  const [selectedDoc, setSelectedDoc] = useState<Doc | null>(null);
+  const [projectFilter, setProjectFilter] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>(null);
+
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingContent = useRef<string | null>(null);
+
+  // ─── Fetch helpers ─────────────────────────────────────────────────────────
+
+  const refreshFolders = useCallback(async () => {
+    try {
+      const res = await fetch('/api/docs/folders');
+      if (!res.ok) return;
+      const { folders: data } = await res.json();
+      setFolders(data);
+    } catch {
+      // silent
+    }
+  }, []);
+
+  const refreshDocs = useCallback(async (folderId?: string | null) => {
+    try {
+      const url = folderId ? `/api/docs?folderId=${folderId}` : '/api/docs';
+      const res = await fetch(url);
+      if (!res.ok) return;
+      const { docs: data } = await res.json();
+      setDocs(data);
+    } catch {
+      // silent
+    }
+  }, []);
+
+  const loadDoc = useCallback(async (docId: string) => {
+    try {
+      const res = await fetch(`/api/docs/${docId}`);
+      if (!res.ok) {
+        setSelectedDoc(null);
+        return;
+      }
+      const { doc } = await res.json();
+      setSelectedDoc(doc);
+    } catch {
+      setSelectedDoc(null);
+    }
+  }, []);
+
+  // ─── Bootstrap ─────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    refreshFolders();
+    refreshDocs(null);
+  }, [refreshFolders, refreshDocs]);
+
+  // Deep-link: if initialDocId provided, load doc on mount
+  useEffect(() => {
+    if (initialDocId) {
+      loadDoc(initialDocId);
+    }
+  }, [initialDocId, loadDoc]);
+
+  // ─── Selection ─────────────────────────────────────────────────────────────
+
+  const selectFolder = useCallback((folderId: string | null) => {
+    setSelectedFolderId(folderId);
+    refreshDocs(folderId);
+  }, [refreshDocs]);
+
+  const selectDoc = useCallback((docId: string | null) => {
+    setSelectedDocId(docId);
+    if (docId) {
+      loadDoc(docId);
+    } else {
+      setSelectedDoc(null);
+    }
+  }, [loadDoc]);
+
+  // ─── Folder actions ────────────────────────────────────────────────────────
+
+  const createFolder = useCallback(async (
+    name: string,
+    parentId?: string | null,
+    projectId?: string | null,
+  ): Promise<DocFolder | null> => {
+    try {
+      const res = await fetch('/api/docs/folders', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, parent_id: parentId ?? null, project_id: projectId ?? null }),
+      });
+      if (!res.ok) return null;
+      const { folder } = await res.json();
+      setFolders((prev) => [...prev, folder]);
+      return folder;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const renameFolder = useCallback(async (id: string, name: string) => {
+    const res = await fetch(`/api/docs/folders/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (!res.ok) return;
+    const { folder } = await res.json();
+    setFolders((prev) => prev.map((f) => (f.id === id ? folder : f)));
+  }, []);
+
+  const deleteFolder = useCallback(async (id: string) => {
+    const res = await fetch(`/api/docs/folders/${id}`, { method: 'DELETE' });
+    if (!res.ok) return;
+    // Remove folder and all descendants from local state
+    setFolders((prev) => {
+      const toRemove = new Set<string>();
+      const findDescendants = (fid: string) => {
+        toRemove.add(fid);
+        prev.filter((f) => f.parent_id === fid).forEach((f) => findDescendants(f.id));
+      };
+      findDescendants(id);
+      return prev.filter((f) => !toRemove.has(f.id));
+    });
+    // If selected folder was deleted, reset
+    if (selectedFolderId === id) {
+      setSelectedFolderId(null);
+      refreshDocs(null);
+    }
+  }, [selectedFolderId, refreshDocs]);
+
+  const moveFolder = useCallback(async (
+    id: string,
+    parentId: string | null,
+    position: number,
+  ) => {
+    // Optimistic update
+    setFolders((prev) =>
+      prev.map((f) => (f.id === id ? { ...f, parent_id: parentId, position } : f)),
+    );
+    try {
+      const res = await fetch(`/api/docs/folders/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ parent_id: parentId, position }),
+      });
+      if (!res.ok) {
+        // Revert on error
+        await refreshFolders();
+      }
+    } catch {
+      await refreshFolders();
+    }
+  }, [refreshFolders]);
+
+  const reorderFolders = useCallback(async (siblings: DocFolder[]) => {
+    // Batch renumber: set positions 0, 1000, 2000...
+    const updates = siblings.map((f, i) => ({ ...f, position: i * 1000 }));
+    setFolders((prev) => {
+      const updateMap = new Map(updates.map((f) => [f.id, f]));
+      return prev.map((f) => updateMap.get(f.id) ?? f);
+    });
+    await Promise.all(
+      updates.map((f) =>
+        fetch(`/api/docs/folders/${f.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ position: f.position }),
+        }),
+      ),
+    );
+  }, []);
+
+  // ─── Doc actions ───────────────────────────────────────────────────────────
+
+  const createDoc = useCallback(async (folderId?: string | null): Promise<Doc | null> => {
+    try {
+      const res = await fetch('/api/docs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ folder_id: folderId ?? selectedFolderId ?? null }),
+      });
+      if (!res.ok) return null;
+      const { doc } = await res.json();
+      setDocs((prev) => [doc, ...prev]);
+      setSelectedDocId(doc.id);
+      setSelectedDoc(doc);
+      return doc;
+    } catch {
+      return null;
+    }
+  }, [selectedFolderId]);
+
+  const deleteDoc = useCallback(async (id: string) => {
+    const res = await fetch(`/api/docs/${id}`, { method: 'DELETE' });
+    if (!res.ok) return;
+    setDocs((prev) => prev.filter((d) => d.id !== id));
+    if (selectedDocId === id) {
+      setSelectedDocId(null);
+      setSelectedDoc(null);
+    }
+  }, [selectedDocId]);
+
+  const moveDoc = useCallback(async (docId: string, folderId: string | null) => {
+    // Optimistic update
+    setDocs((prev) => prev.filter((d) => d.id !== docId));
+    try {
+      const res = await fetch(`/api/docs/${docId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ folder_id: folderId }),
+      });
+      if (!res.ok) {
+        // Revert
+        await refreshDocs(selectedFolderId);
+      } else {
+        const { doc } = await res.json();
+        if (selectedDoc?.id === docId) {
+          setSelectedDoc(doc);
+        }
+      }
+    } catch {
+      await refreshDocs(selectedFolderId);
+    }
+  }, [selectedFolderId, selectedDoc, refreshDocs]);
+
+  // ─── Autosave ──────────────────────────────────────────────────────────────
+
+  const flushSave = useCallback(async () => {
+    if (!selectedDocId || pendingContent.current === null) return;
+    const content = pendingContent.current;
+    pendingContent.current = null;
+    setIsSaving(true);
+    setSaveStatus('saving');
+    try {
+      const res = await fetch(`/api/docs/${selectedDocId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      });
+      if (!res.ok) {
+        setSaveStatus('error');
+        return;
+      }
+      const { doc } = await res.json();
+      setSelectedDoc(doc);
+      setDocs((prev) => prev.map((d) => (d.id === doc.id ? { ...d, updated_at: doc.updated_at } : d)));
+      setSaveStatus('saved');
+    } catch {
+      setSaveStatus('error');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [selectedDocId]);
+
+  const saveDocContent = useCallback((content: string) => {
+    pendingContent.current = content;
+    if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    autosaveTimer.current = setTimeout(() => {
+      flushSave();
+    }, AUTOSAVE_DELAY);
+  }, [flushSave]);
+
+  const saveDocTitle = useCallback(async (title: string) => {
+    if (!selectedDocId) return;
+    try {
+      const res = await fetch(`/api/docs/${selectedDocId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title }),
+      });
+      if (!res.ok) return;
+      const { doc } = await res.json();
+      setSelectedDoc(doc);
+      setDocs((prev) => prev.map((d) => (d.id === doc.id ? { ...d, title: doc.title } : d)));
+    } catch {
+      // silent
+    }
+  }, [selectedDocId]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    };
+  }, []);
+
+  return {
+    folders,
+    docs,
+    selectedFolderId,
+    selectedDocId,
+    selectedDoc,
+    projectFilter,
+    isSaving,
+    saveStatus,
+    selectFolder,
+    selectDoc,
+    setProjectFilter,
+    createFolder,
+    renameFolder,
+    deleteFolder,
+    moveFolder,
+    reorderFolders,
+    createDoc,
+    deleteDoc,
+    moveDoc,
+    saveDocContent,
+    saveDocTitle,
+    refreshFolders,
+    refreshDocs,
+  };
+}

--- a/src/lib/auth/rbac.ts
+++ b/src/lib/auth/rbac.ts
@@ -19,7 +19,9 @@ export type Permission =
   | 'delete_project'
   | 'export'
   | 'view_feedback'
-  | 'manage_feedback';
+  | 'manage_feedback'
+  | 'docs:read'
+  | 'docs:write';
 
 const PERMISSION_MAP: Record<Permission, UserRole[]> = {
   read: ['viewer', 'qa_engineer', 'sdet', 'admin'],
@@ -38,6 +40,10 @@ const PERMISSION_MAP: Record<Permission, UserRole[]> = {
   view_feedback: ['qa_engineer', 'sdet', 'admin'],
   /** manage_feedback — triage (status/notes/export); viewers excluded */
   manage_feedback: ['qa_engineer', 'sdet', 'admin'],
+  /** docs:read — view docs; all authenticated roles */
+  'docs:read': ['viewer', 'qa_engineer', 'sdet', 'admin'],
+  /** docs:write — create/edit/delete docs and folders; editor+ roles */
+  'docs:write': ['qa_engineer', 'sdet', 'admin'],
 };
 
 export function hasPermission(role: UserRole, permission: Permission): boolean {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -540,6 +540,36 @@ export interface NoteWithAttachments extends Note {
   linked_test_cases?: LinkedTestCase[];
 }
 
+// ============================================================
+// Docs
+// ============================================================
+
+export interface DocFolder {
+  id: string;
+  name: string;
+  parent_id: string | null;
+  project_id: string | null;
+  position: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DocSummary {
+  id: string;
+  title: string;
+  folder_id: string | null;
+  project_id: string | null;
+  created_by: string;
+  updated_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Doc extends DocSummary {
+  content: string | null;
+}
+
 export interface DashboardSummary {
   user_section: DashboardUserSection;
   global_section: DashboardGlobalSection;

--- a/supabase/migrations/00033_docs.sql
+++ b/supabase/migrations/00033_docs.sql
@@ -1,0 +1,154 @@
+-- Migration: 00033_docs.sql
+-- Global Docs section: doc_folders and docs tables, indexes, triggers, RLS
+
+-- ============================================================
+-- 1. doc_folders table
+-- ============================================================
+
+CREATE TABLE doc_folders (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        text        NOT NULL CHECK (char_length(name) BETWEEN 1 AND 255),
+  parent_id   uuid        REFERENCES doc_folders(id) ON DELETE CASCADE,
+  project_id  uuid        REFERENCES projects(id) ON DELETE SET NULL,
+  position    integer     NOT NULL DEFAULT 0,
+  created_by  uuid        NOT NULL REFERENCES profiles(id),
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX doc_folders_parent_id_idx  ON doc_folders (parent_id);
+CREATE INDEX doc_folders_project_id_idx ON doc_folders (project_id);
+CREATE INDEX doc_folders_position_idx   ON doc_folders (position);
+
+-- updated_at trigger (conditional moddatetime pattern)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'moddatetime') THEN
+    EXECUTE $SQL$
+      CREATE TRIGGER set_doc_folders_updated_at
+        BEFORE UPDATE ON doc_folders
+        FOR EACH ROW EXECUTE FUNCTION moddatetime(updated_at);
+    $SQL$;
+  ELSE
+    EXECUTE $SQL$
+      CREATE OR REPLACE FUNCTION _doc_folders_set_updated_at()
+      RETURNS TRIGGER AS $TRG$
+      BEGIN NEW.updated_at = now(); RETURN NEW; END;
+      $TRG$ LANGUAGE plpgsql;
+      CREATE TRIGGER set_doc_folders_updated_at
+        BEFORE UPDATE ON doc_folders
+        FOR EACH ROW EXECUTE FUNCTION _doc_folders_set_updated_at();
+    $SQL$;
+  END IF;
+END;
+$$;
+
+-- ============================================================
+-- 2. docs table
+-- ============================================================
+
+CREATE TABLE docs (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  title         text        NOT NULL DEFAULT 'Untitled Document'
+                            CHECK (char_length(title) BETWEEN 1 AND 500),
+  content       text,
+  folder_id     uuid        REFERENCES doc_folders(id) ON DELETE SET NULL,
+  project_id    uuid        REFERENCES projects(id) ON DELETE SET NULL,
+  created_by    uuid        NOT NULL REFERENCES profiles(id),
+  updated_by    uuid        REFERENCES profiles(id),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  search_vector tsvector    GENERATED ALWAYS AS (
+    to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, ''))
+  ) STORED
+);
+
+CREATE INDEX docs_folder_id_idx     ON docs (folder_id);
+CREATE INDEX docs_project_id_idx    ON docs (project_id);
+CREATE INDEX docs_updated_at_idx    ON docs (updated_at DESC);
+CREATE INDEX docs_search_vector_idx ON docs USING GIN (search_vector);
+
+-- updated_at trigger (same conditional moddatetime pattern)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'moddatetime') THEN
+    EXECUTE $SQL$
+      CREATE TRIGGER set_docs_updated_at
+        BEFORE UPDATE ON docs
+        FOR EACH ROW EXECUTE FUNCTION moddatetime(updated_at);
+    $SQL$;
+  ELSE
+    EXECUTE $SQL$
+      CREATE OR REPLACE FUNCTION _docs_set_updated_at()
+      RETURNS TRIGGER AS $TRG$
+      BEGIN NEW.updated_at = now(); RETURN NEW; END;
+      $TRG$ LANGUAGE plpgsql;
+      CREATE TRIGGER set_docs_updated_at
+        BEFORE UPDATE ON docs
+        FOR EACH ROW EXECUTE FUNCTION _docs_set_updated_at();
+    $SQL$;
+  END IF;
+END;
+$$;
+
+-- ============================================================
+-- 3. RLS Policies — doc_folders
+-- ============================================================
+
+ALTER TABLE doc_folders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY doc_folders_select ON doc_folders FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM profiles WHERE profiles.id = auth.uid()));
+
+CREATE POLICY doc_folders_insert ON doc_folders FOR INSERT TO authenticated
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid()
+    AND profiles.role::text IN ('admin', 'sdet', 'qa_engineer')
+  ));
+
+CREATE POLICY doc_folders_update ON doc_folders FOR UPDATE TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid()
+    AND profiles.role::text IN ('admin', 'sdet')
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid()
+    AND profiles.role::text IN ('admin', 'sdet')
+  ));
+
+CREATE POLICY doc_folders_delete ON doc_folders FOR DELETE TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid()
+    AND profiles.role::text IN ('admin', 'sdet')
+  ));
+
+-- ============================================================
+-- 4. RLS Policies — docs
+-- ============================================================
+
+ALTER TABLE docs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY docs_select ON docs FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM profiles WHERE profiles.id = auth.uid()));
+
+CREATE POLICY docs_insert ON docs FOR INSERT TO authenticated
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid()
+    AND profiles.role::text IN ('admin', 'sdet', 'qa_engineer')
+  ));
+
+CREATE POLICY docs_update ON docs FOR UPDATE TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid()
+    AND profiles.role::text IN ('admin', 'sdet', 'qa_engineer')
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid()
+    AND profiles.role::text IN ('admin', 'sdet', 'qa_engineer')
+  ));
+
+CREATE POLICY docs_delete ON docs FOR DELETE TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.id = auth.uid()
+    AND profiles.role::text IN ('admin', 'sdet')
+  ));


### PR DESCRIPTION
## Summary

Implements the TCM Global Docs Section — a full 1:1 functional match to Full Throttle's Docs feature. This is Phase 1 of the FullThrottle → TCM platform consolidation.

**ARC Plan:** ff271044-5edf-448a-afe5-5338e0989204
**Task ID:** 02de8007-b834-4b6e-a4e7-38845813a7b6

---

## What's in this PR

### Database
- `supabase/migrations/00033_docs.sql` — `doc_folders` and `docs` tables, all indexes, conditional moddatetime triggers, full RLS policies

### TypeScript types
- `src/types/database.ts` — `DocFolder`, `DocSummary`, `Doc` interfaces

### API (9 route handlers)
- `GET /api/docs/folders` — flat folder list
- `POST /api/docs/folders` — create folder
- `PATCH /api/docs/folders/[id]` — rename / re-parent / reposition
- `DELETE /api/docs/folders/[id]` — delete (cascade via DB)
- `GET /api/docs` — doc summaries (no content), optional `?folderId=`
- `POST /api/docs` — create doc
- `GET /api/docs/[id]` — full doc with content
- `PATCH /api/docs/[id]` — update title / content / folder / project
- `DELETE /api/docs/[id]` — delete doc

All routes follow `withAuth + createClient` pattern from `/api/notes/route.ts` exactly.

### Hook
- `src/hooks/useDocs.ts` — single state source for folders, docs, selection, project filter; 1500ms debounced autosave; optimistic DnD updates

### Components
- `FolderTree.tsx` — recursive tree, @dnd-kit drag-and-drop reorder, folder CRUD dialogs
- `DocList.tsx` — doc rows with create/delete/context-menu (Move to…, Copy link)
- `DocEditor.tsx` — wraps `NoteEditor.tsx` (Tiptap HTML), inline title edit, autosave indicator, copy link
- `MoveDocModal.tsx` — folder-picker dialog
- `DocsPage.tsx` — 3-column layout shell

### Page
- `src/app/(dashboard)/docs/page.tsx` — mounts useDocs hook, renders DocsPage, handles `?docId=` deep-link

### Existing file edits (2 files only)
- `Sidebar.tsx` — added "Docs" nav item (`MenuBookOutlinedIcon`, `/docs`) between Reports and Feedback
- `rbac.ts` — added `docs:read` (all roles) and `docs:write` (qa_engineer, sdet, admin)

---

## Notes / Deviations from ARC plan

1. **`date-fns` not installed** — ARC plan didn't flag this; used native `Date.toLocaleDateString()` for doc timestamps. No functional impact. Can swap to date-fns if Spencer wants to add it.
2. **`@dnd-kit` already installed** — ARC flagged this as a potential gap; confirmed it was already present (v6/v10/v3). No install needed.
3. **Dev branch created fresh** — No `dev` branch existed on origin. Created from `main` HEAD and pushed. PR targets `dev`.

---

## Pre-merge checklist
- [ ] Run `00033_docs.sql` on Supabase (staging first, then prod)
- [ ] Smoke test: create folder, create doc, edit content, move doc, deep-link
- [ ] Torque review for any UI polish items
- [ ] ARC sign-off on deviations above