### PR TITLE
fix: parse markdown content via manager on editor init

### DIFF
--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -55,8 +55,15 @@ export default function NoteEditor({
       ImageExtension.configure({ inline: true }),
       Markdown,
     ],
-    content,
+    content: '',
     editable: !readOnly,
+    onCreate: ({ editor: e }) => {
+      // Use the markdown manager to parse content so raw markdown is
+      // rendered as formatted nodes instead of plain text.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const json = (e.storage.markdown as any).manager.parse(content ?? '') as import('@tiptap/core').JSONContent;
+      e.commands.setContent(json, { emitUpdate: false });
+    },
     onUpdate: ({ editor: e }) => {
       const markdown = e.getMarkdown();
       const text = e.getText();


### PR DESCRIPTION
## Problem
Docs with markdown content still rendered as raw plain text after #65. Headers, tables, bold, lists all showing as literal syntax.

## Root cause
The `@tiptap/markdown` extension was added but Tiptap's `content` prop still processes the initial value as HTML — not markdown. Passing a raw markdown string as `content` to `useEditor` meant it was treated as plain text, not parsed.

## Fix
Use the `onCreate` hook to explicitly parse the markdown string via `editor.storage.markdown.manager.parse(content)` and call `setContent` with the resulting JSONContent. This forces the Markdown extension's parser to handle the initial content correctly.

## Result
All existing docs stored as markdown will now render with proper formatting on load.

## Files changed
- `src/components/notes/NoteEditor.tsx` — added `onCreate` hook for markdown parse on init

## Verification
- `npm run build` passes ✅
- Existing docs with markdown content (headers, tables, bold, lists) render formatted on load