### PR TITLE
feat: TCM Agent Activity Monitor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# TCM — Environment Variables
+# Copy to .env.local and fill in real values. Never commit .env.local.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# ─── Supabase ────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_SUPABASE_URL=https://<your-project>.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
+
+# ─── Google OAuth ─────────────────────────────────────────────────────────────
+GOOGLE_CLIENT_ID=<your-google-client-id>
+GOOGLE_CLIENT_SECRET=<your-google-client-secret>
+
+# ─── Vercel Cron Security ────────────────────────────────────────────────────
+# Protects /api/cron/* routes. Vercel sets Authorization: Bearer <CRON_SECRET>
+# automatically. Set this to any strong random string.
+CRON_SECRET=<your-cron-secret>
+
+# ─── Agent Activity Monitor ──────────────────────────────────────────────────
+# (Added 2026-05-30 — see ARC plan: Architecture: TCM Agent Activity Monitor)
+
+# Base URL for OpenClaw gateway API (used by kill/restart proxy calls)
+OPENCLAW_API_URL=http://localhost:3001
+
+# Shared API key for TCM-to-OpenClaw server-side calls (X-OpenClaw-Key header)
+OPENCLAW_API_KEY=<your-openclaw-api-key>
+
+# Feature flag: set to "true" only after OpenClaw session kill/spawn API is built.
+# When "false", kill and restart DB updates proceed but OpenClaw is not called.
+# UI shows a warning when this is off.
+OPENCLAW_INTEGRATION_ENABLED=false
+
+# Also expose to the browser so the UI can show/hide the OpenClaw warning:
+NEXT_PUBLIC_OPENCLAW_INTEGRATION_ENABLED=false
+
+# Stale-run timeout window in minutes. Runs with no heartbeat for this long
+# are marked timed_out by the /api/cron/timeout-agent-runs cron job.
+# Default: 10
+AGENT_TIMEOUT_MINUTES=10

--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import Divider from '@mui/material/Divider';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
+import PageTransition from '@/components/animations/PageTransition';
+import AgentFilterBar from '@/components/agents/AgentFilterBar';
+import AgentRunRow from '@/components/agents/AgentRunRow';
+import { useAgentRuns, groupRuns } from '@/hooks/useAgentRuns';
+import type { AgentRunFilters, AgentRun } from '@/types/agent-run';
+
+function AgentsPageInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const filters: AgentRunFilters = {
+    agent: searchParams.get('agent') ?? undefined,
+    status: searchParams.get('status') ?? undefined,
+    projectTag: searchParams.get('projectTag') ?? undefined,
+    includeArchived: searchParams.get('includeArchived') === 'true',
+  };
+
+  const { runs, total, loading, error, refresh } = useAgentRuns(filters);
+  const { top, children } = groupRuns(runs);
+
+  // All run IDs in the response (for orphan detection)
+  const runIdSet = new Set(runs.map((r) => r.id));
+
+  function handleFilterChange(next: AgentRunFilters) {
+    const params = new URLSearchParams();
+    if (next.agent) params.set('agent', next.agent);
+    if (next.status) params.set('status', next.status);
+    if (next.projectTag) params.set('projectTag', next.projectTag);
+    if (next.includeArchived) params.set('includeArchived', 'true');
+    router.push(`/agents${params.toString() ? `?${params.toString()}` : ''}`);
+  }
+
+  // Count active runs for status indicator
+  const TERMINAL = new Set(['done', 'failed', 'timed_out', 'killed']);
+  const activeCount = runs.filter((r) => !TERMINAL.has(r.status)).length;
+
+  // Determine if we have orphan children (parent filtered out / archived)
+  const orphanedChildren: AgentRun[] = [];
+  for (const [parentId, childList] of children.entries()) {
+    if (!runIdSet.has(parentId)) {
+      orphanedChildren.push(...childList);
+    }
+  }
+
+  return (
+    <PageTransition>
+      <Box sx={{ p: 3, maxWidth: 1200, mx: 'auto' }}>
+        {/* Header */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
+          <SmartToyOutlinedIcon sx={{ fontSize: 32, color: 'primary.main' }} />
+          <Box sx={{ flex: 1 }}>
+            <Typography variant="h5" fontWeight={700}>
+              Agent Monitor
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Live view of FullThrottle agent runs
+            </Typography>
+          </Box>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {activeCount > 0 && (
+              <Chip
+                label={`${activeCount} active`}
+                color="primary"
+                size="small"
+                sx={{ fontWeight: 600 }}
+              />
+            )}
+            <Tooltip title="Refresh now">
+              <IconButton onClick={refresh} size="small">
+                <RefreshIcon />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+
+        {/* Filter bar */}
+        <AgentFilterBar filters={filters} onChange={handleFilterChange} />
+
+        {/* Error state */}
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Failed to load runs: {error}
+          </Alert>
+        )}
+
+        {/* Loading state */}
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {/* Empty state */}
+        {!loading && runs.length === 0 && (
+          <Box
+            sx={{
+              textAlign: 'center',
+              py: 8,
+              color: 'text.disabled',
+            }}
+          >
+            <SmartToyOutlinedIcon sx={{ fontSize: 64, mb: 2, opacity: 0.3 }} />
+            <Typography variant="h6" color="text.disabled">
+              No agent runs found
+            </Typography>
+            <Typography variant="body2" color="text.disabled">
+              {Object.values(filters).some(Boolean)
+                ? 'Try adjusting your filters'
+                : 'Runs will appear here when agents are spawned'}
+            </Typography>
+          </Box>
+        )}
+
+        {/* Run list */}
+        {!loading && runs.length > 0 && (
+          <>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+              {total} run{total !== 1 ? 's' : ''} total
+              {activeCount > 0 ? ` · polling every 5s` : ` · polling every 30s`}
+            </Typography>
+
+            <Box>
+              {top.map((run) => {
+                const runChildren = children.get(run.id) ?? [];
+                return (
+                  <Box key={run.id}>
+                    <AgentRunRow run={run} onAction={refresh} />
+                    {runChildren.map((child) => (
+                      <AgentRunRow key={child.id} run={child} isChild onAction={refresh} />
+                    ))}
+                  </Box>
+                );
+              })}
+
+              {/* Orphaned children (parent filtered out / archived) */}
+              {orphanedChildren.length > 0 && (
+                <>
+                  <Divider sx={{ my: 2 }}>
+                    <Typography variant="caption" color="text.disabled">
+                      Orphaned sub-sessions
+                    </Typography>
+                  </Divider>
+                  {orphanedChildren.map((run) => (
+                    <AgentRunRow key={run.id} run={run} isOrphan onAction={refresh} />
+                  ))}
+                </>
+              )}
+            </Box>
+          </>
+        )}
+      </Box>
+    </PageTransition>
+  );
+}
+
+export default function AgentsPage() {
+  return (
+    <Suspense
+      fallback={
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+          <CircularProgress size={32} />
+        </Box>
+      }
+    >
+      <AgentsPageInner />
+    </Suspense>
+  );
+}

--- a/src/app/api/agent-runs/[id]/kill/route.ts
+++ b/src/app/api/agent-runs/[id]/kill/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server';
+import { withAgentAuth, notFound, serverError } from '@/lib/api/helpers';
+import { TERMINAL_STATUSES } from '@/lib/validations/agent-run';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+// POST /api/agent-runs/:id/kill — operator-initiated kill
+export async function POST(_request: Request, context: RouteContext) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  const { id } = await context.params;
+
+  // Fetch record
+  const { data: run, error: fetchErr } = await supabase
+    .from('agent_runs')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (fetchErr || !run) return notFound('Agent run');
+
+  // Already terminal
+  if (TERMINAL_STATUSES.includes(run.status as typeof TERMINAL_STATUSES[number])) {
+    return NextResponse.json(
+      { error: 'Run is already in a terminal state', code: 'ALREADY_TERMINAL' },
+      { status: 409 },
+    );
+  }
+
+  let openClawSkipped = false;
+  let openClawError = false;
+
+  const integrationEnabled = process.env.OPENCLAW_INTEGRATION_ENABLED === 'true';
+
+  if (integrationEnabled) {
+    // Proxy kill call to OpenClaw gateway
+    try {
+      const openClawUrl = process.env.OPENCLAW_API_URL;
+      const openClawKey = process.env.OPENCLAW_API_KEY;
+
+      const killRes = await fetch(`${openClawUrl}/api/sessions/kill`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-OpenClaw-Key': openClawKey ?? '',
+        },
+        body: JSON.stringify({ sessionKey: run.session_key }),
+      });
+
+      // 404 = session already gone — continue anyway
+      if (!killRes.ok && killRes.status !== 404) {
+        console.error('[kill] OpenClaw returned non-OK status', killRes.status);
+        openClawError = true;
+        // Continue — do not block DB update on OpenClaw failure
+      }
+    } catch (err) {
+      console.error('[kill] OpenClaw unreachable', err);
+      openClawError = true;
+      // Kill must proceed even if OpenClaw is unreachable
+    }
+  } else {
+    openClawSkipped = true;
+  }
+
+  // Update DB record
+  const { data: updated, error: updateErr } = await supabase
+    .from('agent_runs')
+    .update({ status: 'killed', ended_at: new Date().toISOString() })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (updateErr || !updated) return serverError(updateErr?.message ?? 'Failed to update run');
+
+  return NextResponse.json({
+    ...toRunResponse(updated),
+    openClawSkipped,
+    openClawError,
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toRunResponse(r: any) {
+  return {
+    id: r.id,
+    agent: r.agent,
+    brief: r.brief,
+    status: r.status,
+    sessionKey: r.session_key,
+    spawnedBy: r.spawned_by,
+    slackChannel: r.slack_channel,
+    slackThreadTs: r.slack_thread_ts,
+    projectTag: r.project_tag,
+    startedAt: r.started_at,
+    lastHeartbeat: r.last_heartbeat,
+    endedAt: r.ended_at,
+    outputTail: r.output_tail,
+    outputTruncated: r.output_truncated,
+    parentRunId: r.parent_run_id,
+    archivedAt: r.archived_at,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}

--- a/src/app/api/agent-runs/[id]/restart/route.ts
+++ b/src/app/api/agent-runs/[id]/restart/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from 'next/server';
+import { withAgentAuth, notFound, serverError } from '@/lib/api/helpers';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+// POST /api/agent-runs/:id/restart — operator-initiated restart
+export async function POST(_request: Request, context: RouteContext) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  const { id } = await context.params;
+
+  // Fetch original record
+  const { data: original, error: fetchErr } = await supabase
+    .from('agent_runs')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (fetchErr || !original) return notFound('Agent run');
+
+  let newSessionKey: string | null = null;
+  let openClawSkipped = false;
+  let openClawError = false;
+
+  const integrationEnabled = process.env.OPENCLAW_INTEGRATION_ENABLED === 'true';
+
+  if (integrationEnabled) {
+    try {
+      const openClawUrl = process.env.OPENCLAW_API_URL;
+      const openClawKey = process.env.OPENCLAW_API_KEY;
+
+      const spawnRes = await fetch(`${openClawUrl}/api/sessions/spawn`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-OpenClaw-Key': openClawKey ?? '',
+        },
+        body: JSON.stringify({
+          agent: original.agent,
+          brief: original.brief,
+          spawnedBy: original.spawned_by,
+          projectTag: original.project_tag,
+        }),
+      });
+
+      if (spawnRes.ok) {
+        const spawnData = await spawnRes.json();
+        newSessionKey = spawnData.sessionKey ?? null;
+      } else {
+        console.error('[restart] OpenClaw spawn failed', spawnRes.status);
+        openClawError = true;
+      }
+    } catch (err) {
+      console.error('[restart] OpenClaw unreachable', err);
+      openClawError = true;
+    }
+  } else {
+    openClawSkipped = true;
+  }
+
+  // If OpenClaw didn't provide a session key, generate a placeholder
+  if (!newSessionKey) {
+    newSessionKey = `restart-${original.session_key}-${Date.now()}`;
+  }
+
+  const now = new Date().toISOString();
+
+  // Insert new top-level run (restart is fresh, parentRunId = null)
+  const { data: newRun, error: insertErr } = await supabase
+    .from('agent_runs')
+    .insert({
+      agent: original.agent,
+      brief: original.brief,
+      session_key: newSessionKey,
+      spawned_by: original.spawned_by,
+      slack_channel: original.slack_channel,
+      slack_thread_ts: original.slack_thread_ts,
+      project_tag: original.project_tag,
+      started_at: now,
+      status: 'spawned',
+      parent_run_id: null,
+      output_truncated: false,
+    })
+    .select()
+    .single();
+
+  if (insertErr || !newRun) return serverError(insertErr?.message ?? 'Failed to create restart run');
+
+  return NextResponse.json(
+    {
+      ...toRunResponse(newRun),
+      openClawSkipped,
+      openClawError,
+    },
+    { status: 201 },
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toRunResponse(r: any) {
+  return {
+    id: r.id,
+    agent: r.agent,
+    brief: r.brief,
+    status: r.status,
+    sessionKey: r.session_key,
+    spawnedBy: r.spawned_by,
+    slackChannel: r.slack_channel,
+    slackThreadTs: r.slack_thread_ts,
+    projectTag: r.project_tag,
+    startedAt: r.started_at,
+    lastHeartbeat: r.last_heartbeat,
+    endedAt: r.ended_at,
+    outputTail: r.output_tail,
+    outputTruncated: r.output_truncated,
+    parentRunId: r.parent_run_id,
+    archivedAt: r.archived_at,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}

--- a/src/app/api/agent-runs/[id]/route.ts
+++ b/src/app/api/agent-runs/[id]/route.ts
@@ -1,0 +1,142 @@
+import { NextResponse } from 'next/server';
+import { withAgentAuth, validationError, notFound, serverError } from '@/lib/api/helpers';
+import { PatchRunSchema, TERMINAL_STATUSES, OUTPUT_TAIL_MAX_BYTES } from '@/lib/validations/agent-run';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+// PATCH /api/agent-runs/:id — lifecycle updates and heartbeats
+export async function PATCH(request: Request, context: RouteContext) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  const { id } = await context.params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return validationError('Invalid JSON body');
+  }
+
+  const parsed = PatchRunSchema.safeParse(body);
+  if (!parsed.success) return validationError(parsed.error.flatten());
+
+  const { status, lastHeartbeat, outputTail, endedAt } = parsed.data;
+
+  // Fetch existing record
+  const { data: existing, error: fetchErr } = await supabase
+    .from('agent_runs')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (fetchErr || !existing) return notFound('Agent run');
+
+  // Guard: reject status change if run is already terminal
+  const isTerminal = TERMINAL_STATUSES.includes(existing.status as typeof TERMINAL_STATUSES[number]);
+  if (status && isTerminal) {
+    return NextResponse.json(
+      { error: 'Cannot update a terminal run', code: 'ILLEGAL_TRANSITION' },
+      { status: 409 },
+    );
+  }
+
+  // output_tail truncation (server-side enforcement)
+  let finalOutputTail = outputTail;
+  let outputTruncated = existing.output_truncated as boolean;
+
+  if (finalOutputTail !== undefined) {
+    const byteLen = Buffer.byteLength(finalOutputTail, 'utf8');
+    if (byteLen > OUTPUT_TAIL_MAX_BYTES) {
+      const buf = Buffer.from(finalOutputTail, 'utf8');
+      finalOutputTail = buf.slice(buf.byteLength - OUTPUT_TAIL_MAX_BYTES).toString('utf8');
+      outputTruncated = true;
+    }
+  }
+
+  // Build update payload — only include defined fields
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updatePayload: Record<string, any> = {};
+  if (status !== undefined) updatePayload.status = status;
+  if (lastHeartbeat !== undefined) updatePayload.last_heartbeat = lastHeartbeat;
+  if (finalOutputTail !== undefined) {
+    updatePayload.output_tail = finalOutputTail;
+    updatePayload.output_truncated = outputTruncated;
+  }
+  if (endedAt !== undefined) updatePayload.ended_at = endedAt;
+
+  // Atomic UPDATE with stale-heartbeat guard and terminal-state guard
+  // Build WHERE conditions using supabase filters (service client, so RLS bypassed)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let query = (supabase as any)
+    .from('agent_runs')
+    .update(updatePayload)
+    .eq('id', id)
+    .not('status', 'in', `(${TERMINAL_STATUSES.join(',')})`)
+    .select()
+    .single();
+
+  // Stale heartbeat guard: only apply when lastHeartbeat is being set and existing is non-null
+  if (lastHeartbeat && existing.last_heartbeat) {
+    query = query.lt('last_heartbeat', lastHeartbeat);
+  }
+
+  const { data: updated, error: updateErr } = await query;
+
+  if (updateErr || !updated) {
+    // Re-fetch to determine cause of 0-row update
+    const { data: recheck } = await supabase
+      .from('agent_runs')
+      .select('status, last_heartbeat')
+      .eq('id', id)
+      .single();
+
+    if (!recheck) return notFound('Agent run');
+
+    // Terminal state blocked the update
+    if (TERMINAL_STATUSES.includes(recheck.status as typeof TERMINAL_STATUSES[number])) {
+      return NextResponse.json(
+        { error: 'Cannot update a terminal run', code: 'ILLEGAL_TRANSITION' },
+        { status: 409 },
+      );
+    }
+
+    // Stale heartbeat — silent dedup, not an error
+    const { data: current } = await supabase
+      .from('agent_runs')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    return NextResponse.json(toRunResponse(current));
+  }
+
+  return NextResponse.json(toRunResponse(updated));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toRunResponse(r: any) {
+  return {
+    id: r.id,
+    agent: r.agent,
+    brief: r.brief,
+    status: r.status,
+    sessionKey: r.session_key,
+    spawnedBy: r.spawned_by,
+    slackChannel: r.slack_channel,
+    slackThreadTs: r.slack_thread_ts,
+    projectTag: r.project_tag,
+    startedAt: r.started_at,
+    lastHeartbeat: r.last_heartbeat,
+    endedAt: r.ended_at,
+    outputTail: r.output_tail,
+    outputTruncated: r.output_truncated,
+    parentRunId: r.parent_run_id,
+    archivedAt: r.archived_at,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}

--- a/src/app/api/agent-runs/route.ts
+++ b/src/app/api/agent-runs/route.ts
@@ -1,0 +1,173 @@
+import { NextResponse } from 'next/server';
+import { withAgentAuth, validationError, serverError } from '@/lib/api/helpers';
+import { CreateRunSchema, OUTPUT_TAIL_MAX_BYTES } from '@/lib/validations/agent-run';
+
+// POST /api/agent-runs — register new run at spawn time
+export async function POST(request: Request) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return validationError('Invalid JSON body');
+  }
+
+  const parsed = CreateRunSchema.safeParse(body);
+  if (!parsed.success) return validationError(parsed.error.flatten());
+
+  const {
+    agent,
+    brief,
+    sessionKey,
+    spawnedBy,
+    slackChannel,
+    slackThreadTs,
+    projectTag,
+    startedAt,
+    parentRunId,
+  } = parsed.data;
+
+  // Verify parentRunId exists if supplied
+  if (parentRunId) {
+    const { data: parent, error: parentErr } = await supabase
+      .from('agent_runs')
+      .select('id')
+      .eq('id', parentRunId)
+      .single();
+
+    if (parentErr || !parent) {
+      return NextResponse.json(
+        { error: 'Parent run not found', code: 'PARENT_NOT_FOUND' },
+        { status: 404 },
+      );
+    }
+  }
+
+  const { data: run, error } = await supabase
+    .from('agent_runs')
+    .insert({
+      agent,
+      brief,
+      session_key: sessionKey,
+      spawned_by: spawnedBy,
+      slack_channel: slackChannel ?? null,
+      slack_thread_ts: slackThreadTs ?? null,
+      project_tag: projectTag ?? null,
+      started_at: startedAt,
+      parent_run_id: parentRunId ?? null,
+      output_truncated: false,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    // Unique constraint violation on session_key
+    if (error.code === '23505') {
+      return NextResponse.json(
+        { error: 'Session key already exists', code: 'SESSION_KEY_CONFLICT' },
+        { status: 409 },
+      );
+    }
+    return serverError(error.message);
+  }
+
+  return NextResponse.json(toRunResponse(run), { status: 201 });
+}
+
+// GET /api/agent-runs — list runs with filters and pagination
+export async function GET(request: Request) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  const { searchParams } = new URL(request.url);
+  const statusParam = searchParams.get('status');
+  const agentParam = searchParams.get('agent');
+  const projectTag = searchParams.get('projectTag');
+  const parentRunId = searchParams.get('parentRunId');
+  const includeArchived = searchParams.get('includeArchived') === 'true';
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '100', 10), 100);
+  const offset = parseInt(searchParams.get('offset') ?? '0', 10);
+
+  const statusFilter = statusParam ? statusParam.split(',').filter(Boolean) : null;
+  const agentFilter = agentParam ? agentParam.split(',').filter(Boolean) : null;
+
+  // Build query
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let query = (supabase as any)
+    .from('agent_runs')
+    .select('*', { count: 'exact' })
+    .order('started_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (!includeArchived) {
+    query = query.is('archived_at', null);
+  }
+  if (statusFilter?.length) {
+    query = query.in('status', statusFilter);
+  }
+  if (agentFilter?.length) {
+    query = query.in('agent', agentFilter);
+  }
+  if (projectTag) {
+    query = query.eq('project_tag', projectTag);
+  }
+  if (parentRunId) {
+    query = query.eq('parent_run_id', parentRunId);
+  }
+
+  const { data: runs, error, count } = await query;
+  if (error) return serverError(error.message);
+
+  // Enforce output tail size cap on reads too (belt-and-suspenders)
+  const mappedRuns = (runs ?? []).map((r: Record<string, unknown>) => {
+    if (typeof r.output_tail === 'string' && Buffer.byteLength(r.output_tail) > OUTPUT_TAIL_MAX_BYTES) {
+      const truncated = truncateFromFront(r.output_tail);
+      return { ...r, output_tail: truncated, output_truncated: true };
+    }
+    return r;
+  });
+
+  return NextResponse.json({
+    runs: mappedRuns.map(toRunResponse),
+    total: count ?? 0,
+    limit,
+    offset,
+  });
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function truncateFromFront(text: string): string {
+  // Keep last OUTPUT_TAIL_MAX_BYTES bytes (UTF-8 aware trim)
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.byteLength <= OUTPUT_TAIL_MAX_BYTES) return text;
+  return buf.slice(buf.byteLength - OUTPUT_TAIL_MAX_BYTES).toString('utf8');
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toRunResponse(r: any) {
+  return {
+    id: r.id,
+    agent: r.agent,
+    brief: r.brief,
+    status: r.status,
+    sessionKey: r.session_key,
+    spawnedBy: r.spawned_by,
+    slackChannel: r.slack_channel,
+    slackThreadTs: r.slack_thread_ts,
+    projectTag: r.project_tag,
+    startedAt: r.started_at,
+    lastHeartbeat: r.last_heartbeat,
+    endedAt: r.ended_at,
+    outputTail: r.output_tail,
+    outputTruncated: r.output_truncated,
+    parentRunId: r.parent_run_id,
+    archivedAt: r.archived_at,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}

--- a/src/app/api/cron/archive-agent-runs/route.ts
+++ b/src/app/api/cron/archive-agent-runs/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+
+// Vercel Cron: hourly — soft-archive terminal runs older than 24h
+// vercel.json config: { "crons": [{ "path": "/api/cron/archive-agent-runs", "schedule": "0 * * * *" }] }
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  // Guard: only allow Vercel Cron or internal calls
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = await createServiceClient();
+
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: archived, error } = await supabase
+    .from('agent_runs')
+    .update({ archived_at: new Date().toISOString() })
+    .in('status', ['done', 'failed', 'timed_out', 'killed'])
+    .lt('ended_at', cutoff)
+    .is('archived_at', null)
+    .select('id');
+
+  if (error) {
+    console.error('[cron:archive-agent-runs] Archive failed', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    archived: archived?.length ?? 0,
+    cutoff,
+  });
+}

--- a/src/app/api/cron/timeout-agent-runs/route.ts
+++ b/src/app/api/cron/timeout-agent-runs/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+
+// Vercel Cron: every 2 minutes — mark stale active runs as timed_out
+// vercel.json config: { "crons": [{ "path": "/api/cron/timeout-agent-runs", "schedule": "*/2 * * * *" }] }
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  // Guard: only allow Vercel Cron or internal calls
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = await createServiceClient();
+
+  const timeoutMinutes = parseInt(process.env.AGENT_TIMEOUT_MINUTES ?? '10', 10);
+  const cutoff = new Date(Date.now() - timeoutMinutes * 60 * 1000).toISOString();
+
+  // Mark stale active runs as timed_out
+  // "stale" = last_heartbeat (or started_at if no heartbeat) older than cutoff
+  const { data, error } = await supabase.rpc('timeout_stale_agent_runs', {
+    cutoff_ts: cutoff,
+  });
+
+  if (error) {
+    // Fallback: raw update if RPC not available
+    const { data: updated, error: updateErr } = await supabase
+      .from('agent_runs')
+      .update({ status: 'timed_out', ended_at: new Date().toISOString() })
+      .in('status', ['spawned', 'running', 'waiting'])
+      .is('archived_at', null)
+      .or(`last_heartbeat.lt.${cutoff},and(last_heartbeat.is.null,started_at.lt.${cutoff})`)
+      .select('id');
+
+    if (updateErr) {
+      console.error('[cron:timeout-agent-runs] Update failed', updateErr);
+      return NextResponse.json({ error: updateErr.message }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      timedOut: updated?.length ?? 0,
+      cutoff,
+      timeoutMinutes,
+    });
+  }
+
+  return NextResponse.json({
+    timedOut: data ?? 0,
+    cutoff,
+    timeoutMinutes,
+  });
+}

--- a/src/components/agents/AgentBadge.tsx
+++ b/src/components/agents/AgentBadge.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Chip from '@mui/material/Chip';
+import type { AgentName } from '@/types/agent-run';
+
+const AGENT_COLORS: Record<AgentName, string> = {
+  axel: '#1565C0',
+  riff: '#6A1B9A',
+  arc: '#00695C',
+  torque: '#E65100',
+  clutch: '#37474F',
+};
+
+interface Props {
+  agent: AgentName;
+  size?: 'small' | 'medium';
+}
+
+export default function AgentBadge({ agent, size = 'small' }: Props) {
+  const color = AGENT_COLORS[agent] ?? '#607D8B';
+  const label = agent.charAt(0).toUpperCase() + agent.slice(1);
+  return (
+    <Chip
+      label={label}
+      size={size}
+      sx={{
+        bgcolor: color,
+        color: '#fff',
+        fontWeight: 700,
+        fontSize: '0.72rem',
+        letterSpacing: '0.04em',
+      }}
+    />
+  );
+}

--- a/src/components/agents/AgentFilterBar.tsx
+++ b/src/components/agents/AgentFilterBar.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
+import type { AgentRunFilters } from '@/types/agent-run';
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All statuses' },
+  { value: 'spawned', label: 'Spawned' },
+  { value: 'running', label: 'Running' },
+  { value: 'waiting', label: 'Waiting' },
+  { value: 'done', label: 'Done' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'timed_out', label: 'Timed Out' },
+  { value: 'killed', label: 'Killed' },
+];
+
+const AGENT_OPTIONS = [
+  { value: '', label: 'All agents' },
+  { value: 'axel', label: 'Axel' },
+  { value: 'riff', label: 'Riff' },
+  { value: 'arc', label: 'ARC' },
+  { value: 'torque', label: 'Torque' },
+  { value: 'clutch', label: 'Clutch' },
+];
+
+interface Props {
+  filters: AgentRunFilters;
+  onChange: (filters: AgentRunFilters) => void;
+}
+
+export default function AgentFilterBar({ filters, onChange }: Props) {
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center', mb: 2 }}>
+      <FormControl size="small" sx={{ minWidth: 160 }}>
+        <InputLabel>Agent</InputLabel>
+        <Select
+          value={filters.agent ?? ''}
+          label="Agent"
+          onChange={(e) => onChange({ ...filters, agent: e.target.value || undefined })}
+        >
+          {AGENT_OPTIONS.map((o) => (
+            <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl size="small" sx={{ minWidth: 160 }}>
+        <InputLabel>Status</InputLabel>
+        <Select
+          value={filters.status ?? ''}
+          label="Status"
+          onChange={(e) => onChange({ ...filters, status: e.target.value || undefined })}
+        >
+          {STATUS_OPTIONS.map((o) => (
+            <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <TextField
+        size="small"
+        label="Project"
+        value={filters.projectTag ?? ''}
+        onChange={(e) => onChange({ ...filters, projectTag: e.target.value || undefined })}
+        sx={{ minWidth: 150 }}
+        placeholder="e.g. fullthrottle"
+      />
+
+      <FormControlLabel
+        control={
+          <Switch
+            size="small"
+            checked={!!filters.includeArchived}
+            onChange={(e) => onChange({ ...filters, includeArchived: e.target.checked })}
+          />
+        }
+        label="Include archived"
+        sx={{ ml: 0 }}
+      />
+    </Box>
+  );
+}

--- a/src/components/agents/AgentRunRow.tsx
+++ b/src/components/agents/AgentRunRow.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Alert from '@mui/material/Alert';
+import StopIcon from '@mui/icons-material/Stop';
+import ReplayIcon from '@mui/icons-material/Replay';
+import AgentStatusBadge from './AgentStatusBadge';
+import AgentBadge from './AgentBadge';
+import ElapsedTime from './ElapsedTime';
+import HeartbeatCell from './HeartbeatCell';
+import OutputPanel from './OutputPanel';
+import type { AgentRun } from '@/types/agent-run';
+
+const TERMINAL_STATUSES = new Set(['done', 'failed', 'timed_out', 'killed']);
+const ACTIVE_STATUSES = new Set(['spawned', 'running', 'waiting']);
+
+interface Props {
+  run: AgentRun;
+  isChild?: boolean;
+  isOrphan?: boolean;
+  onAction?: () => void;
+}
+
+export default function AgentRunRow({ run, isChild = false, isOrphan = false, onAction }: Props) {
+  const [killDialogOpen, setKillDialogOpen] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [openClawWarning, setOpenClawWarning] = useState(false);
+
+  const isActive = ACTIVE_STATUSES.has(run.status);
+  const isTerminal = TERMINAL_STATUSES.has(run.status);
+
+  const integrationEnabled = process.env.NEXT_PUBLIC_OPENCLAW_INTEGRATION_ENABLED === 'true';
+
+  async function handleKill() {
+    setActionLoading(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/agent-runs/${run.id}/kill`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Kill failed');
+      if (data.openClawSkipped || data.openClawError) setOpenClawWarning(true);
+      onAction?.();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Kill failed');
+    } finally {
+      setActionLoading(false);
+      setKillDialogOpen(false);
+    }
+  }
+
+  async function handleRestart() {
+    setActionLoading(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/agent-runs/${run.id}/restart`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Restart failed');
+      if (data.openClawSkipped || data.openClawError) setOpenClawWarning(true);
+      onAction?.();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Restart failed');
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        ml: isChild ? 4 : 0,
+        mt: 1,
+        p: 2,
+        borderLeft: isChild ? '3px solid' : undefined,
+        borderLeftColor: isChild ? 'primary.light' : undefined,
+        opacity: run.archivedAt ? 0.65 : 1,
+      }}
+    >
+      {/* Header row */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, flexWrap: 'wrap' }}>
+        <AgentBadge agent={run.agent} />
+        <AgentStatusBadge status={run.status} />
+
+        {isOrphan && (
+          <Typography variant="caption" color="text.disabled" sx={{ alignSelf: 'center' }}>
+            (sub-session)
+          </Typography>
+        )}
+
+        <Typography
+          variant="body2"
+          sx={{ flex: 1, minWidth: 200, fontWeight: 500, alignSelf: 'center' }}
+          title={run.brief}
+        >
+          {run.brief.length > 120 ? `${run.brief.slice(0, 120)}…` : run.brief}
+        </Typography>
+
+        {run.projectTag && (
+          <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>
+            {run.projectTag}
+          </Typography>
+        )}
+      </Box>
+
+      {/* Meta row */}
+      <Box sx={{ display: 'flex', gap: 3, mt: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+        <Box>
+          <Typography variant="caption" color="text.disabled">Elapsed</Typography>
+          <ElapsedTime
+            startedAt={run.startedAt}
+            endedAt={run.endedAt}
+            isActive={isActive}
+          />
+        </Box>
+
+        <Box>
+          <Typography variant="caption" color="text.disabled">Heartbeat</Typography>
+          <HeartbeatCell lastHeartbeat={run.lastHeartbeat} status={run.status} />
+        </Box>
+
+        <Box>
+          <Typography variant="caption" color="text.disabled">Spawned by</Typography>
+          <Typography variant="body2" color="text.secondary">{run.spawnedBy}</Typography>
+        </Box>
+
+        {run.slackChannel && (
+          <Box>
+            <Typography variant="caption" color="text.disabled">Slack</Typography>
+            <Typography variant="body2" color="text.secondary">
+              {run.slackChannel}
+              {run.slackThreadTs ? ` / ${run.slackThreadTs}` : ''}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      {/* Output panel */}
+      <Box sx={{ mt: 1.5 }}>
+        <OutputPanel outputTail={run.outputTail} outputTruncated={run.outputTruncated} />
+      </Box>
+
+      {/* Errors and warnings */}
+      {actionError && (
+        <Alert severity="error" sx={{ mt: 1 }} onClose={() => setActionError(null)}>
+          {actionError}
+        </Alert>
+      )}
+      {openClawWarning && (
+        <Alert severity="warning" sx={{ mt: 1 }} onClose={() => setOpenClawWarning(false)}>
+          Agent may still be running — OpenClaw integration is not yet active. DB record updated, but the session was not terminated remotely.
+        </Alert>
+      )}
+
+      {/* Actions */}
+      <Box sx={{ display: 'flex', gap: 1, mt: 1.5 }}>
+        {isActive && (
+          <Tooltip
+            title={
+              !integrationEnabled
+                ? 'Agent termination requires OpenClaw integration — not yet available'
+                : 'Kill this run'
+            }
+          >
+            <span>
+              <Button
+                size="small"
+                variant="outlined"
+                color="error"
+                startIcon={<StopIcon />}
+                onClick={() => setKillDialogOpen(true)}
+                disabled={actionLoading}
+                sx={{ textTransform: 'none' }}
+              >
+                Kill
+              </Button>
+            </span>
+          </Tooltip>
+        )}
+
+        {isTerminal && (
+          <Tooltip
+            title={
+              !integrationEnabled
+                ? 'Agent restart requires OpenClaw integration — not yet available'
+                : 'Restart this run with the same brief'
+            }
+          >
+            <span>
+              <Button
+                size="small"
+                variant="outlined"
+                color="primary"
+                startIcon={<ReplayIcon />}
+                onClick={handleRestart}
+                disabled={actionLoading}
+                sx={{ textTransform: 'none' }}
+              >
+                Restart
+              </Button>
+            </span>
+          </Tooltip>
+        )}
+      </Box>
+
+      {/* Kill confirmation dialog */}
+      <Dialog open={killDialogOpen} onClose={() => setKillDialogOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Kill run?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This will mark the run as killed
+            {!integrationEnabled ? ' (OpenClaw integration is off — the agent process may still be running)' : ''}.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setKillDialogOpen(false)} disabled={actionLoading}>
+            Cancel
+          </Button>
+          <Button onClick={handleKill} color="error" disabled={actionLoading} autoFocus>
+            Kill
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Paper>
+  );
+}

--- a/src/components/agents/AgentStatusBadge.tsx
+++ b/src/components/agents/AgentStatusBadge.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Chip from '@mui/material/Chip';
+import type { AgentRunStatus } from '@/types/agent-run';
+
+const STATUS_CONFIG: Record<
+  AgentRunStatus,
+  { label: string; color: 'default' | 'primary' | 'secondary' | 'success' | 'error' | 'warning' | 'info' }
+> = {
+  spawned: { label: 'Spawned', color: 'secondary' },
+  running: { label: 'Running', color: 'primary' },
+  waiting: { label: 'Waiting', color: 'info' },
+  done: { label: 'Done', color: 'success' },
+  failed: { label: 'Failed', color: 'error' },
+  timed_out: { label: 'Timed Out', color: 'warning' },
+  killed: { label: 'Killed', color: 'default' },
+};
+
+interface Props {
+  status: AgentRunStatus;
+  size?: 'small' | 'medium';
+}
+
+export default function AgentStatusBadge({ status, size = 'small' }: Props) {
+  const config = STATUS_CONFIG[status] ?? { label: status, color: 'default' };
+  return (
+    <Chip
+      label={config.label}
+      color={config.color}
+      size={size}
+      sx={{ fontWeight: 600, fontSize: '0.72rem', letterSpacing: '0.02em' }}
+    />
+  );
+}

--- a/src/components/agents/ElapsedTime.tsx
+++ b/src/components/agents/ElapsedTime.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Typography from '@mui/material/Typography';
+
+function formatElapsed(ms: number): string {
+  if (ms < 0) ms = 0;
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+interface Props {
+  startedAt: string;
+  endedAt: string | null;
+  isActive: boolean;
+}
+
+export default function ElapsedTime({ startedAt, endedAt, isActive }: Props) {
+  const [elapsed, setElapsed] = useState(() => {
+    const end = endedAt ? new Date(endedAt).getTime() : Date.now();
+    return end - new Date(startedAt).getTime();
+  });
+
+  useEffect(() => {
+    if (!isActive || endedAt) return;
+
+    const interval = setInterval(() => {
+      setElapsed(Date.now() - new Date(startedAt).getTime());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [startedAt, endedAt, isActive]);
+
+  return (
+    <Typography variant="body2" sx={{ fontVariantNumeric: 'tabular-nums', color: 'text.secondary' }}>
+      {formatElapsed(elapsed)}
+    </Typography>
+  );
+}

--- a/src/components/agents/HeartbeatCell.tsx
+++ b/src/components/agents/HeartbeatCell.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import type { AgentRunStatus } from '@/types/agent-run';
+
+const TERMINAL_STATUSES = new Set(['done', 'failed', 'timed_out', 'killed']);
+const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+
+function formatRelative(ts: string): string {
+  const ago = Date.now() - new Date(ts).getTime();
+  const seconds = Math.floor(ago / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+interface Props {
+  lastHeartbeat: string | null;
+  status: AgentRunStatus;
+}
+
+export default function HeartbeatCell({ lastHeartbeat, status }: Props) {
+  if (!lastHeartbeat) {
+    return <Typography variant="body2" color="text.disabled">—</Typography>;
+  }
+
+  const isActive = !TERMINAL_STATUSES.has(status);
+  const ageMs = Date.now() - new Date(lastHeartbeat).getTime();
+  const isStale = isActive && ageMs > STALE_THRESHOLD_MS;
+
+  return (
+    <Tooltip title={new Date(lastHeartbeat).toLocaleString()}>
+      <Typography
+        variant="body2"
+        sx={{
+          color: isStale ? 'error.main' : 'text.secondary',
+          fontWeight: isStale ? 600 : 400,
+        }}
+      >
+        {formatRelative(lastHeartbeat)}
+        {isStale ? ' ⚠' : ''}
+      </Typography>
+    </Tooltip>
+  );
+}

--- a/src/components/agents/OutputPanel.tsx
+++ b/src/components/agents/OutputPanel.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Collapse from '@mui/material/Collapse';
+import Alert from '@mui/material/Alert';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import Typography from '@mui/material/Typography';
+
+interface Props {
+  outputTail: string | null;
+  outputTruncated: boolean;
+}
+
+export default function OutputPanel({ outputTail, outputTruncated }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  if (!outputTail) {
+    return (
+      <Typography variant="body2" color="text.disabled" sx={{ pl: 1 }}>
+        No output yet
+      </Typography>
+    );
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(outputTail);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <Box>
+      <Button
+        size="small"
+        startIcon={expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        onClick={() => setExpanded((v) => !v)}
+        sx={{ mb: 0.5, textTransform: 'none', fontSize: '0.75rem' }}
+      >
+        {expanded ? 'Collapse output' : 'Expand output'}
+      </Button>
+
+      <Collapse in={expanded}>
+        <Box sx={{ position: 'relative' }}>
+          {outputTruncated && (
+            <Alert severity="warning" sx={{ mb: 1, py: 0.5, fontSize: '0.75rem' }}>
+              Output was truncated — only the most recent content is shown.
+            </Alert>
+          )}
+
+          <Box
+            sx={{
+              position: 'relative',
+              bgcolor: '#1a1a2e',
+              borderRadius: 1,
+              p: 1.5,
+              maxHeight: 320,
+              overflow: 'auto',
+            }}
+          >
+            <Tooltip title={copied ? 'Copied!' : 'Copy output'}>
+              <IconButton
+                size="small"
+                onClick={handleCopy}
+                sx={{
+                  position: 'absolute',
+                  top: 8,
+                  right: 8,
+                  color: '#aaa',
+                  '&:hover': { color: '#fff' },
+                }}
+              >
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+
+            <pre
+              style={{
+                margin: 0,
+                fontFamily: '"JetBrains Mono", "Fira Code", "Courier New", monospace',
+                fontSize: '0.72rem',
+                lineHeight: 1.6,
+                color: '#e0e0e0',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-all',
+              }}
+            >
+              {outputTail}
+            </pre>
+          </Box>
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -29,6 +29,7 @@ import InboxOutlinedIcon from '@mui/icons-material/InboxOutlined';
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 import { motion } from 'framer-motion';
 import { useAuth } from '@/components/providers/AuthProvider';
 import { ROLE_LABELS } from '@/lib/auth/rbac';
@@ -53,6 +54,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Projects', href: '/projects', icon: <FolderOutlinedIcon /> },
   { label: 'Test Runs', href: '/runs', icon: <PlaylistPlayIcon /> },
   { label: 'Reports', href: '/reports', icon: <AssessmentOutlinedIcon /> },
+  { label: 'Agents', href: '/agents', icon: <SmartToyOutlinedIcon /> },
   { label: 'Docs', href: '/docs', icon: <MenuBookOutlinedIcon /> },
   { label: 'Feedback', href: '/feedback-inbox', icon: <InboxOutlinedIcon />, permission: 'view_feedback' as const },
   { label: 'Integrations', href: '/integrations', icon: <WebhookOutlinedIcon />, permission: 'view_webhooks' },

--- a/src/hooks/useAgentRuns.ts
+++ b/src/hooks/useAgentRuns.ts
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { AgentRun, AgentRunFilters } from '@/types/agent-run';
+
+const TERMINAL_STATUSES = new Set(['done', 'failed', 'timed_out', 'killed']);
+
+const ACTIVE_INTERVAL_MS = 5_000;
+const IDLE_INTERVAL_MS = 30_000;
+
+function buildUrl(filters: AgentRunFilters): string {
+  const params = new URLSearchParams();
+  if (filters.status) params.set('status', filters.status);
+  if (filters.agent) params.set('agent', filters.agent);
+  if (filters.projectTag) params.set('projectTag', filters.projectTag);
+  if (filters.includeArchived) params.set('includeArchived', 'true');
+  params.set('limit', '100');
+  return `/api/agent-runs?${params.toString()}`;
+}
+
+export function useAgentRuns(filters: AgentRunFilters) {
+  const [runs, setRuns] = useState<AgentRun[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const consecutiveErrorsRef = useRef(0);
+
+  const hasActive = runs.some((r) => !TERMINAL_STATUSES.has(r.status));
+  const intervalMs = hasActive ? ACTIVE_INTERVAL_MS : IDLE_INTERVAL_MS;
+
+  const fetchRuns = useCallback(async () => {
+    try {
+      const res = await fetch(buildUrl(filters));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      if (!cancelledRef.current) {
+        setRuns(data.runs ?? []);
+        setTotal(data.total ?? 0);
+        setError(null);
+        consecutiveErrorsRef.current = 0;
+      }
+    } catch (err) {
+      consecutiveErrorsRef.current += 1;
+      if (consecutiveErrorsRef.current >= 3) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch runs');
+      }
+    } finally {
+      if (!cancelledRef.current) setLoading(false);
+    }
+  }, [filters]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    setLoading(true);
+
+    function poll() {
+      if (cancelledRef.current) return;
+      if (document.hidden) {
+        // Tab hidden — skip fetch, schedule next check
+        timerRef.current = setTimeout(poll, intervalMs);
+        return;
+      }
+      fetchRuns().finally(() => {
+        if (!cancelledRef.current) {
+          timerRef.current = setTimeout(poll, intervalMs);
+        }
+      });
+    }
+
+    // Immediate initial fetch
+    fetchRuns().finally(() => {
+      if (!cancelledRef.current) {
+        timerRef.current = setTimeout(poll, intervalMs);
+      }
+    });
+
+    function onVisibilityChange() {
+      if (!document.hidden && !cancelledRef.current) {
+        if (timerRef.current) clearTimeout(timerRef.current);
+        // Resume immediately on tab focus
+        fetchRuns().finally(() => {
+          if (!cancelledRef.current) {
+            timerRef.current = setTimeout(poll, intervalMs);
+          }
+        });
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      cancelledRef.current = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [fetchRuns, intervalMs]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const refresh = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    fetchRuns().finally(() => {
+      if (!cancelledRef.current) {
+        timerRef.current = setTimeout(() => {}, intervalMs);
+      }
+    });
+  }, [fetchRuns, intervalMs]);
+
+  return { runs, total, loading, error, refresh };
+}
+
+// ─── Parent/child grouping ───────────────────────────────────────────────────
+
+export interface GroupedRuns {
+  top: AgentRun[];
+  children: Map<string, AgentRun[]>;
+}
+
+export function groupRuns(runs: AgentRun[]): GroupedRuns {
+  const childMap = new Map<string, AgentRun[]>();
+  const topLevel: AgentRun[] = [];
+
+  for (const run of runs) {
+    if (run.parentRunId) {
+      const siblings = childMap.get(run.parentRunId) ?? [];
+      siblings.push(run);
+      childMap.set(run.parentRunId, siblings);
+    } else {
+      topLevel.push(run);
+    }
+  }
+
+  return { top: topLevel, children: childMap };
+}

--- a/src/lib/api/helpers.ts
+++ b/src/lib/api/helpers.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
 import { hasPermission, type Permission } from '@/lib/auth/rbac';
 import type { Profile, UserRole } from '@/types/database';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { headers } from 'next/headers';
 
 export interface AuthContext {
   user: { id: string; email?: string };
@@ -103,4 +104,49 @@ export function serverError(message = 'Internal server error') {
     { error: message },
     { status: 500 },
   );
+}
+
+/**
+ * Dual-auth helper for the agent-runs API.
+ * Accepts either:
+ *  - Supabase session cookie (browser)
+ *  - Authorization: Bearer <supabase-jwt> (Clutch server-to-server)
+ *
+ * Returns a service-role Supabase client so route handlers can bypass RLS
+ * when writing on behalf of agents. Auth is still validated — only the DB
+ * client is elevated.
+ */
+export async function withAgentAuth(): Promise<
+  { ok: true; supabase: SupabaseClient } | { ok: false; response: NextResponse }
+> {
+  const headerStore = await headers();
+  const authorization = headerStore.get('authorization') ?? '';
+
+  if (authorization.startsWith('Bearer ')) {
+    const token = authorization.slice(7);
+    // Validate the JWT against Supabase by fetching the user
+    const supabase = await createServiceClient();
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data.user) {
+      return {
+        ok: false,
+        response: NextResponse.json({ error: 'Unauthorized', code: 'UNAUTHORIZED' }, { status: 401 }),
+      };
+    }
+    return { ok: true, supabase };
+  }
+
+  // Fall back to cookie auth
+  const cookieClient = await createClient();
+  const { data, error } = await cookieClient.auth.getUser();
+  if (error || !data.user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Unauthorized', code: 'UNAUTHORIZED' }, { status: 401 }),
+    };
+  }
+
+  // Return service client so RLS doesn't interfere with agent-runs writes
+  const supabase = await createServiceClient();
+  return { ok: true, supabase };
 }

--- a/src/lib/validations/agent-run.ts
+++ b/src/lib/validations/agent-run.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const TERMINAL_STATUSES = ['done', 'failed', 'timed_out', 'killed'] as const;
+export const VALID_AGENTS = ['axel', 'riff', 'arc', 'torque', 'clutch'] as const;
+export const VALID_STATUSES = ['spawned', 'running', 'waiting', 'done', 'failed', 'timed_out', 'killed'] as const;
+
+export const OUTPUT_TAIL_MAX_BYTES = 65_536;
+
+export const CreateRunSchema = z.object({
+  agent: z.enum(VALID_AGENTS),
+  brief: z.string().min(1).max(512),
+  sessionKey: z.string().min(1).max(128),
+  spawnedBy: z.string().min(1).max(256),
+  slackChannel: z.string().max(64).optional(),
+  slackThreadTs: z.string().max(64).optional(),
+  projectTag: z.string().max(64).optional(),
+  startedAt: z.string().datetime(),
+  parentRunId: z.string().uuid().optional().nullable(),
+});
+
+export const PatchRunSchema = z
+  .object({
+    status: z.enum(VALID_STATUSES).optional(),
+    lastHeartbeat: z.string().datetime().optional(),
+    outputTail: z.string().optional(),
+    endedAt: z.string().datetime().optional().nullable(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'Patch body must not be empty',
+  });
+
+export type CreateRunInput = z.infer<typeof CreateRunSchema>;
+export type PatchRunInput = z.infer<typeof PatchRunSchema>;

--- a/src/types/agent-run.ts
+++ b/src/types/agent-run.ts
@@ -1,0 +1,46 @@
+export type AgentRunStatus =
+  | 'spawned'
+  | 'running'
+  | 'waiting'
+  | 'done'
+  | 'failed'
+  | 'timed_out'
+  | 'killed';
+
+export type AgentName = 'axel' | 'riff' | 'arc' | 'torque' | 'clutch';
+
+export interface AgentRun {
+  id: string;
+  agent: AgentName;
+  brief: string;
+  status: AgentRunStatus;
+  sessionKey: string;
+  spawnedBy: string;
+  slackChannel: string | null;
+  slackThreadTs: string | null;
+  projectTag: string | null;
+  startedAt: string;
+  lastHeartbeat: string | null;
+  endedAt: string | null;
+  outputTail: string | null;
+  outputTruncated: boolean;
+  parentRunId: string | null;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AgentRunsResponse {
+  runs: AgentRun[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface AgentRunFilters {
+  status?: string;
+  agent?: string;
+  projectTag?: string;
+  search?: string;
+  includeArchived?: boolean;
+}

--- a/supabase/migrations/00034_agent_runs.sql
+++ b/supabase/migrations/00034_agent_runs.sql
@@ -1,0 +1,105 @@
+-- Agent Activity Monitor — agent_runs table
+-- Implements: ARC plan "Architecture: TCM Agent Activity Monitor" (2026-05-30)
+
+-- Status enum (enforced at DB level)
+CREATE TYPE agent_run_status AS ENUM (
+  'spawned',
+  'running',
+  'waiting',
+  'done',
+  'failed',
+  'timed_out',
+  'killed'
+);
+
+-- Agent enum
+CREATE TYPE agent_name AS ENUM (
+  'axel', 'riff', 'arc', 'torque', 'clutch'
+);
+
+-- Main table
+CREATE TABLE agent_runs (
+  id               UUID              PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent            agent_name        NOT NULL,
+  brief            TEXT              NOT NULL CHECK (char_length(brief) <= 512),
+  status           agent_run_status  NOT NULL DEFAULT 'spawned',
+  session_key      VARCHAR(128)      NOT NULL UNIQUE,
+  spawned_by       VARCHAR(256)      NOT NULL,
+  slack_channel    VARCHAR(64),
+  slack_thread_ts  VARCHAR(64),
+  project_tag      VARCHAR(64),
+  started_at       TIMESTAMPTZ       NOT NULL,
+  last_heartbeat   TIMESTAMPTZ,
+  ended_at         TIMESTAMPTZ,
+  output_tail      TEXT,
+  output_truncated BOOLEAN           NOT NULL DEFAULT FALSE,
+  parent_run_id    UUID              REFERENCES agent_runs(id) ON DELETE SET NULL,
+  archived_at      TIMESTAMPTZ,
+  created_at       TIMESTAMPTZ       NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ       NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX idx_agent_runs_status        ON agent_runs(status);
+CREATE INDEX idx_agent_runs_agent         ON agent_runs(agent);
+CREATE INDEX idx_agent_runs_project_tag   ON agent_runs(project_tag);
+CREATE INDEX idx_agent_runs_parent_run_id ON agent_runs(parent_run_id);
+CREATE INDEX idx_agent_runs_spawned_by    ON agent_runs(spawned_by);
+CREATE INDEX idx_agent_runs_started_at    ON agent_runs(started_at DESC);
+CREATE INDEX idx_agent_runs_active        ON agent_runs(status) WHERE archived_at IS NULL;
+-- Partial index for default list query (non-archived)
+CREATE INDEX idx_agent_runs_unarchived    ON agent_runs(started_at DESC) WHERE archived_at IS NULL;
+
+-- Auto-update updated_at trigger function (create only if not already defined)
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER agent_runs_updated_at
+  BEFORE UPDATE ON agent_runs
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- RLS: permissive authenticated-user policy (single-org tool)
+ALTER TABLE agent_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY agent_runs_authenticated ON agent_runs
+  FOR ALL TO authenticated USING (true) WITH CHECK (true);
+
+-- Cron jobs (via pg_cron if available)
+DO $guard$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    -- Timeout cron: every 2 minutes — mark stale active runs as timed_out
+    PERFORM cron.schedule(
+      'timeout-agent-runs',
+      '*/2 * * * *',
+      $$
+        UPDATE agent_runs
+        SET status = 'timed_out', ended_at = now(), updated_at = now()
+        WHERE status IN ('spawned', 'running', 'waiting')
+          AND archived_at IS NULL
+          AND COALESCE(last_heartbeat, started_at) < now() - (
+            COALESCE(current_setting('app.agent_timeout_minutes', true), '10')::int * interval '1 minute'
+          );
+      $$
+    );
+
+    -- Archive cron: hourly — soft-archive terminal runs older than 24h
+    PERFORM cron.schedule(
+      'archive-agent-runs',
+      '0 * * * *',
+      $$
+        UPDATE agent_runs
+        SET archived_at = now(), updated_at = now()
+        WHERE status IN ('done', 'failed', 'timed_out', 'killed')
+          AND ended_at < now() - INTERVAL '24 hours'
+          AND archived_at IS NULL;
+      $$
+    );
+  END IF;
+END;
+$guard$;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/timeout-agent-runs",
+      "schedule": "*/2 * * * *"
+    },
+    {
+      "path": "/api/cron/archive-agent-runs",
+      "schedule": "0 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the full Agent Activity Monitor from ARC plan (2026-05-30).

FullThrottle task: `1e3add58-c73c-48dd-9db4-9f07f5217a25`

---

## What's in this PR

### Schema (migration `00034_agent_runs.sql`)
- `agent_run_status` enum: spawned, running, waiting, done, failed, timed_out, killed
- `agent_name` enum: axel, riff, arc, torque, clutch
- `agent_runs` table with all columns, FK, 8 indexes, `updated_at` trigger
- RLS permissive authenticated-user policy
- pg_cron schedules (timeout every 2min, archive hourly)

### API (5 routes, dual cookie+Bearer auth)
- `POST   /api/agent-runs` — register run at spawn
- `PATCH  /api/agent-runs/:id` — lifecycle updates + heartbeat (atomic stale guard + terminal guard)
- `GET    /api/agent-runs` — list with filters (agent/status/projectTag/includeArchived), pagination
- `POST   /api/agent-runs/:id/kill` — kill with OpenClaw proxy (feature-flagged)
- `POST   /api/agent-runs/:id/restart` — restart with OpenClaw proxy (feature-flagged)

### Background cron jobs (Vercel Cron via `vercel.json`)
- `/api/cron/timeout-agent-runs` — every 2 minutes, marks stalled runs `timed_out`
- `/api/cron/archive-agent-runs` — hourly, soft-archives terminal runs older than 24h

### Frontend — `/agents` page
- Adaptive polling hook (5s active / 30s idle / paused on hidden tab)
- Status badges for all 7 states
- Agent color badges (per-agent color)
- Elapsed time (live-updating for active runs)
- Heartbeat cell (red when >5min stale on active run)
- Expandable output tail (accordion, monospaced dark bg, copy button)
- `output_truncated` banner
- Parent/child row grouping (client-side, max depth 1)
- Orphan detection for children whose parent is filtered/archived
- Filter bar: agent / status / projectTag / includeArchived (URL-reflected)
- Kill button (active runs) + Restart button (terminal runs)
- OpenClaw feature flag: warning tooltip when `OPENCLAW_INTEGRATION_ENABLED=false`
- `/agents` added to sidebar nav

### Env vars (documented in `.env.example`)
| Var | Default | Purpose |
|-----|---------|---------|
| `OPENCLAW_API_URL` | — | OpenClaw gateway base URL |
| `OPENCLAW_API_KEY` | — | X-OpenClaw-Key auth header |
| `OPENCLAW_INTEGRATION_ENABLED` | `false` | Feature flag — kill/restart proxy |
| `NEXT_PUBLIC_OPENCLAW_INTEGRATION_ENABLED` | `false` | UI warning flag |
| `AGENT_TIMEOUT_MINUTES` | `10` | Stale-run timeout window |

---

## Notes for reviewers

- **Kill/Restart OpenClaw integration ships behind flag.** `OPENCLAW_INTEGRATION_ENABLED=false` by default until OpenClaw session API is built. DB updates proceed in either case.
- **Clutch instrumentation is a separate task.** The monitor is only as useful as its write coverage. Clutch must POST to `/api/agent-runs` on every `sessions_spawn` — tracked separately.
- **Pre-existing TS error in `knowledge-base/route.ts`** is unrelated and was present before this branch.