### PR TITLE
fix: memoize filters in AgentsPage — stops infinite re-render loop

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -22,12 +22,17 @@ function AgentsPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const filters: AgentRunFilters = {
+  const filters: AgentRunFilters = useMemo(() => ({
     agent: searchParams.get('agent') ?? undefined,
     status: searchParams.get('status') ?? undefined,
     projectTag: searchParams.get('projectTag') ?? undefined,
     includeArchived: searchParams.get('includeArchived') === 'true',
-  };
+  }), [
+    searchParams.get('agent'),
+    searchParams.get('status'),
+    searchParams.get('projectTag'),
+    searchParams.get('includeArchived'),
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { runs, total, loading, error, refresh } = useAgentRuns(filters);
   const { top, children } = groupRuns(runs);


### PR DESCRIPTION
## Bug

`/agents` page loads continuously forever.

## Root cause

`filters` in `AgentsPageInner` was created as a plain object literal on every render:

```ts
const filters: AgentRunFilters = {
  agent: searchParams.get('agent') ?? undefined,
  // ...
};
```

This meant `filters` was always a new object reference every render. `useCallback([filters])` in `useAgentRuns` saw a new dependency on every render → recreated `fetchRuns` every render → `useEffect([fetchRuns, intervalMs])` re-ran every render → called `setLoading(true)` + triggered a fetch → caused a re-render → loop.

## Fix

Wrap `filters` in `useMemo` keyed to the individual primitive `searchParams` values. Reference only changes when actual filter params change.

```ts
const filters = useMemo(() => ({
  agent: searchParams.get('agent') ?? undefined,
  // ...
}), [
  searchParams.get('agent'),
  searchParams.get('status'),
  searchParams.get('projectTag'),
  searchParams.get('includeArchived'),
]);
```

## Also note

The Supabase migration (`00034_agent_runs.sql`) still needs to be applied to the production DB. The page will show an empty state once the loop is fixed, but the API will 500 until the table exists.