### PR TITLE
feat: add X-Clutch-Key header auth to withAgentAuth()

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,6 @@ NEXT_PUBLIC_OPENCLAW_INTEGRATION_ENABLED=false
 # are marked timed_out by the /api/cron/timeout-agent-runs cron job.
 # Default: 10
 AGENT_TIMEOUT_MINUTES=10
+
+# Server-to-server key for Clutch agent monitor writes (generate with: openssl rand -hex 32)
+CLUTCH_API_KEY=

--- a/src/lib/api/helpers.ts
+++ b/src/lib/api/helpers.ts
@@ -108,9 +108,10 @@ export function serverError(message = 'Internal server error') {
 
 /**
  * Dual-auth helper for the agent-runs API.
- * Accepts either:
- *  - Supabase session cookie (browser)
- *  - Authorization: Bearer <supabase-jwt> (Clutch server-to-server)
+ * Accepts, in priority order:
+ *  1. X-Clutch-Key: <key> header (server-to-server, validated against CLUTCH_API_KEY env var)
+ *  2. Authorization: Bearer <supabase-jwt> (Clutch legacy server-to-server)
+ *  3. Supabase session cookie (browser)
  *
  * Returns a service-role Supabase client so route handlers can bypass RLS
  * when writing on behalf of agents. Auth is still validated — only the DB
@@ -120,6 +121,17 @@ export async function withAgentAuth(): Promise<
   { ok: true; supabase: SupabaseClient } | { ok: false; response: NextResponse }
 > {
   const headerStore = await headers();
+
+  // Path 1: X-Clutch-Key header (server-to-server API key auth)
+  const clutchKey = headerStore.get('x-clutch-key');
+  if (clutchKey !== null) {
+    if (clutchKey !== process.env.CLUTCH_API_KEY || !process.env.CLUTCH_API_KEY) {
+      return { ok: false, response: NextResponse.json({ error: 'Unauthorized', code: 'UNAUTHORIZED' }, { status: 401 }) };
+    }
+    const supabase = await createServiceClient();
+    return { ok: true, supabase };
+  }
+
   const authorization = headerStore.get('authorization') ?? '';
 
   if (authorization.startsWith('Bearer ')) {


### PR DESCRIPTION
## What changed

Adds `X-Clutch-Key` header support as a third auth path in `withAgentAuth()` in `src/lib/api/helpers.ts`.

## Why

The agent-runs endpoint needs a lightweight server-to-server auth path for Clutch (the FullThrottle orchestrator) that doesn't require a Supabase JWT. A static API key validated against an env var is simpler and avoids token expiry issues for long-running agent monitors.

## How it works

The new check is inserted **before** the existing Bearer JWT and cookie paths:

1. If `X-Clutch-Key` header is **present and matches** `CLUTCH_API_KEY` env var: return service client, bypass Supabase auth entirely
2. If `X-Clutch-Key` header is **present but does not match** (or env var is unset): return 401 immediately, no fall-through to other auth methods
3. If `X-Clutch-Key` header is **absent**: fall through to existing Bearer JWT and cookie auth paths unchanged

## Files changed

- `src/lib/api/helpers.ts` — additive auth path in `withAgentAuth()`
- `.env.example` — documents `CLUTCH_API_KEY` with generation instructions

## No behavior changes

All existing auth paths (Bearer JWT, cookie) are unaffected. The new path is checked first and only activates when the header is present.