### PR TITLE
fix: add /api/agent-runs to middleware PUBLIC_PATHS

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,7 @@ const PUBLIC_PATHS = [
   '/auth/callback',
   '/invite',
   '/api/webhooks',
+  '/api/agent-runs',       // auth handled in route handler (X-Clutch-Key or Supabase JWT)
   '/feedback',                 // public submission form page
   '/api/feedback/projects',    // public project list for form dropdown
 ];


### PR DESCRIPTION
## Bug

`POST /api/agent-runs` from Clutch (server-to-server with `X-Clutch-Key`) was getting a 307 redirect to `/login` before the request ever reached the route handler.

## Root cause

Middleware checks for a Supabase session on every route. `/api/agent-runs` wasn't in `PUBLIC_PATHS`, so all requests without a browser cookie got redirected — including valid `X-Clutch-Key` requests.

## Fix

Add `/api/agent-runs` to `PUBLIC_PATHS`. Auth is already enforced inside `withAgentAuth()` in the route handler (validates `X-Clutch-Key` against `CLUTCH_API_KEY` env var, or falls back to Supabase JWT/cookie). The middleware check is redundant here and was the blocker.