### PR TITLE
feat: Kanban board view for Agent Monitor

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useMemo } from 'react';
+import { Suspense, useMemo, useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -10,17 +10,62 @@ import Divider from '@mui/material/Divider';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import DashboardIcon from '@mui/icons-material/Dashboard';
 import PageTransition from '@/components/animations/PageTransition';
 import AgentFilterBar from '@/components/agents/AgentFilterBar';
 import AgentRunRow from '@/components/agents/AgentRunRow';
+import AgentKanbanBoard from '@/components/agents/AgentKanbanBoard';
 import { useAgentRuns, groupRuns } from '@/hooks/useAgentRuns';
 import type { AgentRunFilters, AgentRun } from '@/types/agent-run';
+import type { BoardGrouping } from '@/components/agents/AgentKanbanBoard';
+
+type ViewMode = 'list' | 'board';
+
+const VIEW_MODE_KEY = 'agents-view-mode';
+const BOARD_GROUP_KEY = 'agents-board-group';
 
 function AgentsPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
+
+  // View mode — persisted in localStorage
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [boardGrouping, setBoardGrouping] = useState<BoardGrouping>('status');
+
+  useEffect(() => {
+    try {
+      const storedView = localStorage.getItem(VIEW_MODE_KEY) as ViewMode | null;
+      if (storedView === 'list' || storedView === 'board') setViewMode(storedView);
+      const storedGroup = localStorage.getItem(BOARD_GROUP_KEY) as BoardGrouping | null;
+      if (storedGroup === 'status' || storedGroup === 'agent') setBoardGrouping(storedGroup);
+    } catch {
+      // localStorage unavailable — use defaults
+    }
+  }, []);
+
+  function handleViewModeChange(_: React.MouseEvent<HTMLElement>, value: ViewMode | null) {
+    if (!value) return;
+    setViewMode(value);
+    try {
+      localStorage.setItem(VIEW_MODE_KEY, value);
+    } catch {
+      // ignore
+    }
+  }
+
+  function handleBoardGroupingChange(next: BoardGrouping) {
+    setBoardGrouping(next);
+    try {
+      localStorage.setItem(BOARD_GROUP_KEY, next);
+    } catch {
+      // ignore
+    }
+  }
 
   const filters: AgentRunFilters = useMemo(() => ({
     agent: searchParams.get('agent') ?? undefined,
@@ -63,7 +108,7 @@ function AgentsPageInner() {
 
   return (
     <PageTransition>
-      <Box sx={{ p: 3, maxWidth: 1200, mx: 'auto' }}>
+      <Box sx={{ p: 3, maxWidth: viewMode === 'board' ? 'none' : 1200, mx: 'auto' }}>
         {/* Header */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
           <SmartToyOutlinedIcon sx={{ fontSize: 32, color: 'primary.main' }} />
@@ -85,6 +130,27 @@ function AgentsPageInner() {
                 sx={{ fontWeight: 600 }}
               />
             )}
+
+            {/* View mode toggle */}
+            <ToggleButtonGroup
+              value={viewMode}
+              exclusive
+              onChange={handleViewModeChange}
+              size="small"
+              aria-label="view mode"
+            >
+              <ToggleButton value="list" aria-label="list view">
+                <Tooltip title="List view">
+                  <ViewListIcon fontSize="small" />
+                </Tooltip>
+              </ToggleButton>
+              <ToggleButton value="board" aria-label="board view">
+                <Tooltip title="Board view">
+                  <DashboardIcon fontSize="small" />
+                </Tooltip>
+              </ToggleButton>
+            </ToggleButtonGroup>
+
             <Tooltip title="Refresh now">
               <IconButton onClick={refresh} size="small">
                 <RefreshIcon />
@@ -131,8 +197,25 @@ function AgentsPageInner() {
           </Box>
         )}
 
-        {/* Run list */}
-        {!loading && runs.length > 0 && (
+        {/* ── Board view ─────────────────────────────────────────── */}
+        {!loading && runs.length > 0 && viewMode === 'board' && (
+          <>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+              {total} run{total !== 1 ? 's' : ''} total
+              {activeCount > 0 ? ` · polling every 5s` : ` · polling every 30s`}
+            </Typography>
+            <AgentKanbanBoard
+              runs={runs}
+              childMap={children}
+              grouping={boardGrouping}
+              onGroupingChange={handleBoardGroupingChange}
+              onAction={refresh}
+            />
+          </>
+        )}
+
+        {/* ── List view (unchanged) ───────────────────────────────── */}
+        {!loading && runs.length > 0 && viewMode === 'list' && (
           <>
             <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
               {total} run{total !== 1 ? 's' : ''} total

--- a/src/components/agents/AgentKanbanBoard.tsx
+++ b/src/components/agents/AgentKanbanBoard.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import Typography from '@mui/material/Typography';
+import TableRowsIcon from '@mui/icons-material/TableRows';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
+import AgentKanbanColumn from './AgentKanbanColumn';
+import type { AgentRun, AgentRunStatus, AgentName } from '@/types/agent-run';
+
+export type BoardGrouping = 'status' | 'agent';
+
+const STATUS_COLUMNS: AgentRunStatus[] = [
+  'spawned',
+  'running',
+  'waiting',
+  'done',
+  'failed',
+  'timed_out',
+  'killed',
+];
+
+const STATUS_LABELS: Record<AgentRunStatus, string> = {
+  spawned: 'Spawned',
+  running: 'Running',
+  waiting: 'Waiting',
+  done: 'Done',
+  failed: 'Failed',
+  timed_out: 'Timed Out',
+  killed: 'Killed',
+};
+
+const AGENT_COLUMNS: AgentName[] = ['riff', 'arc', 'axel', 'torque', 'clutch'];
+
+const AGENT_LABELS: Record<AgentName, string> = {
+  riff: 'Riff',
+  arc: 'ARC',
+  axel: 'Axel',
+  torque: 'Torque',
+  clutch: 'Clutch',
+};
+
+interface Props {
+  runs: AgentRun[];
+  childMap: Map<string, AgentRun[]>;
+  grouping: BoardGrouping;
+  onGroupingChange: (next: BoardGrouping) => void;
+  onAction?: () => void;
+}
+
+export default function AgentKanbanBoard({
+  runs,
+  childMap,
+  grouping,
+  onGroupingChange,
+  onAction,
+}: Props) {
+  // Only use top-level runs for column grouping; children render inside their parent card
+  const topLevel = runs.filter((r) => !r.parentRunId);
+
+  function handleGroupingChange(_: React.MouseEvent<HTMLElement>, value: BoardGrouping | null) {
+    if (value) onGroupingChange(value);
+  }
+
+  const columns =
+    grouping === 'status'
+      ? STATUS_COLUMNS.map((status) => ({
+          key: status,
+          label: STATUS_LABELS[status],
+          runs: topLevel.filter((r) => r.status === status),
+        }))
+      : AGENT_COLUMNS.map((agent) => ({
+          key: agent,
+          label: AGENT_LABELS[agent],
+          runs: topLevel.filter((r) => r.agent === agent),
+        }));
+
+  return (
+    <Box>
+      {/* Board grouping toggle */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+          Group by
+        </Typography>
+        <ToggleButtonGroup
+          value={grouping}
+          exclusive
+          onChange={handleGroupingChange}
+          size="small"
+          aria-label="board grouping"
+        >
+          <ToggleButton value="status" aria-label="group by status">
+            <TableRowsIcon sx={{ fontSize: 16, mr: 0.5 }} />
+            <Typography variant="caption" sx={{ fontWeight: 600, textTransform: 'none' }}>
+              Status
+            </Typography>
+          </ToggleButton>
+          <ToggleButton value="agent" aria-label="group by agent">
+            <PersonOutlineIcon sx={{ fontSize: 16, mr: 0.5 }} />
+            <Typography variant="caption" sx={{ fontWeight: 600, textTransform: 'none' }}>
+              Agent
+            </Typography>
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+
+      {/* Board columns */}
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 2,
+          overflowX: 'auto',
+          pb: 2,
+          alignItems: 'flex-start',
+          '&::-webkit-scrollbar': { height: 6 },
+          '&::-webkit-scrollbar-thumb': { bgcolor: 'divider', borderRadius: 3 },
+        }}
+      >
+        {columns.map((col) => (
+          <AgentKanbanColumn
+            key={col.key}
+            label={col.label}
+            runs={col.runs}
+            childMap={childMap}
+            onAction={onAction}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/agents/AgentKanbanCard.tsx
+++ b/src/components/agents/AgentKanbanCard.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardActions from '@mui/material/CardActions';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Alert from '@mui/material/Alert';
+import Tooltip from '@mui/material/Tooltip';
+import StopIcon from '@mui/icons-material/Stop';
+import ReplayIcon from '@mui/icons-material/Replay';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import AgentBadge from './AgentBadge';
+import AgentStatusBadge from './AgentStatusBadge';
+import ElapsedTime from './ElapsedTime';
+import HeartbeatCell from './HeartbeatCell';
+import OutputPanel from './OutputPanel';
+import type { AgentRun } from '@/types/agent-run';
+
+const TERMINAL_STATUSES = new Set(['done', 'failed', 'timed_out', 'killed']);
+const ACTIVE_STATUSES = new Set(['spawned', 'running', 'waiting']);
+
+interface Props {
+  run: AgentRun;
+  children?: AgentRun[];
+  isChild?: boolean;
+  onAction?: () => void;
+}
+
+export default function AgentKanbanCard({ run, children = [], isChild = false, onAction }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [killDialogOpen, setKillDialogOpen] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [openClawWarning, setOpenClawWarning] = useState(false);
+
+  const isActive = ACTIVE_STATUSES.has(run.status);
+  const isTerminal = TERMINAL_STATUSES.has(run.status);
+  const integrationEnabled = process.env.NEXT_PUBLIC_OPENCLAW_INTEGRATION_ENABLED === 'true';
+
+  async function handleKill() {
+    setActionLoading(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/agent-runs/${run.id}/kill`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Kill failed');
+      if (data.openClawSkipped || data.openClawError) setOpenClawWarning(true);
+      onAction?.();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Kill failed');
+    } finally {
+      setActionLoading(false);
+      setKillDialogOpen(false);
+    }
+  }
+
+  async function handleRestart() {
+    setActionLoading(true);
+    setActionError(null);
+    try {
+      const res = await fetch(`/api/agent-runs/${run.id}/restart`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Restart failed');
+      if (data.openClawSkipped || data.openClawError) setOpenClawWarning(true);
+      onAction?.();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Restart failed');
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        mb: 1,
+        ml: isChild ? 2 : 0,
+        opacity: run.archivedAt ? 0.65 : 1,
+        borderLeft: isChild ? '3px solid' : undefined,
+        borderLeftColor: isChild ? 'primary.light' : undefined,
+        cursor: 'default',
+        '&:hover': {
+          boxShadow: isChild ? undefined : 2,
+        },
+      }}
+    >
+      <CardContent sx={{ pb: '4px !important', pt: 1.5, px: 1.5 }}>
+        {/* Badge row */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap', mb: 0.75 }}>
+          <AgentBadge agent={run.agent} />
+          <AgentStatusBadge status={run.status} />
+        </Box>
+
+        {/* Brief (2-line clamp) */}
+        <Typography
+          variant="body2"
+          sx={{
+            fontWeight: 500,
+            fontSize: '0.8rem',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            mb: 0.75,
+            lineHeight: 1.4,
+          }}
+          title={run.brief}
+        >
+          {run.brief}
+        </Typography>
+
+        {/* Meta row */}
+        <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+          <Box>
+            <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.65rem' }}>
+              Elapsed
+            </Typography>
+            <ElapsedTime startedAt={run.startedAt} endedAt={run.endedAt} isActive={isActive} />
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.65rem' }}>
+              Heartbeat
+            </Typography>
+            <HeartbeatCell lastHeartbeat={run.lastHeartbeat} status={run.status} />
+          </Box>
+        </Box>
+
+        {/* Spawned by + Slack */}
+        <Box sx={{ mt: 0.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.68rem' }}>
+            {run.spawnedBy}
+            {run.slackChannel ? ` · ${run.slackChannel}` : ''}
+          </Typography>
+        </Box>
+
+        {/* Errors / warnings */}
+        {actionError && (
+          <Alert severity="error" sx={{ mt: 1, py: 0 }} onClose={() => setActionError(null)}>
+            {actionError}
+          </Alert>
+        )}
+        {openClawWarning && (
+          <Alert severity="warning" sx={{ mt: 1, py: 0 }} onClose={() => setOpenClawWarning(false)}>
+            OpenClaw integration not active — DB record updated but session was not terminated remotely.
+          </Alert>
+        )}
+
+        {/* Expand toggle */}
+        <Button
+          size="small"
+          startIcon={expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          onClick={() => setExpanded((v) => !v)}
+          sx={{ mt: 0.5, textTransform: 'none', fontSize: '0.72rem', p: 0, minWidth: 0 }}
+        >
+          {expanded ? 'Hide output' : 'Show output'}
+        </Button>
+
+        {/* Output panel (shown when expanded) */}
+        {expanded && (
+          <Box sx={{ mt: 1 }}>
+            <OutputPanel outputTail={run.outputTail} outputTruncated={run.outputTruncated} />
+          </Box>
+        )}
+      </CardContent>
+
+      {/* Action buttons */}
+      {(isActive || isTerminal) && (
+        <CardActions sx={{ px: 1.5, pt: 0, pb: 1 }}>
+          {isActive && (
+            <Tooltip
+              title={
+                !integrationEnabled
+                  ? 'Agent termination requires OpenClaw integration — not yet available'
+                  : 'Kill this run'
+              }
+            >
+              <span>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  startIcon={<StopIcon />}
+                  onClick={() => setKillDialogOpen(true)}
+                  disabled={actionLoading}
+                  sx={{ textTransform: 'none', fontSize: '0.72rem' }}
+                >
+                  Kill
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+          {isTerminal && (
+            <Tooltip
+              title={
+                !integrationEnabled
+                  ? 'Agent restart requires OpenClaw integration — not yet available'
+                  : 'Restart this run with the same brief'
+              }
+            >
+              <span>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                  startIcon={<ReplayIcon />}
+                  onClick={handleRestart}
+                  disabled={actionLoading}
+                  sx={{ textTransform: 'none', fontSize: '0.72rem' }}
+                >
+                  Restart
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+        </CardActions>
+      )}
+
+      {/* Kill confirmation dialog */}
+      <Dialog open={killDialogOpen} onClose={() => setKillDialogOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Kill run?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This will mark the run as killed
+            {!integrationEnabled
+              ? ' (OpenClaw integration is off — the agent process may still be running)'
+              : ''}
+            .
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setKillDialogOpen(false)} disabled={actionLoading}>
+            Cancel
+          </Button>
+          <Button onClick={handleKill} color="error" disabled={actionLoading} autoFocus>
+            Kill
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Child run sub-cards */}
+      {children.length > 0 && (
+        <Box sx={{ px: 1.5, pb: 1.5 }}>
+          {children.map((child) => (
+            <AgentKanbanCard key={child.id} run={child} isChild onAction={onAction} />
+          ))}
+        </Box>
+      )}
+    </Card>
+  );
+}

--- a/src/components/agents/AgentKanbanColumn.tsx
+++ b/src/components/agents/AgentKanbanColumn.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
+import AgentKanbanCard from './AgentKanbanCard';
+import type { AgentRun } from '@/types/agent-run';
+
+interface Props {
+  label: string;
+  runs: AgentRun[];
+  childMap: Map<string, AgentRun[]>;
+  onAction?: () => void;
+}
+
+export default function AgentKanbanColumn({ label, runs, childMap, onAction }: Props) {
+  // Sort newest first (by createdAt descending)
+  const sorted = [...runs].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  const count = runs.length;
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        minWidth: 280,
+        maxWidth: 320,
+        flex: '0 0 300px',
+        display: 'flex',
+        flexDirection: 'column',
+        maxHeight: 'calc(100vh - 220px)',
+        borderRadius: 2,
+        bgcolor: 'background.default',
+      }}
+    >
+      {/* Column header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: 1.5,
+          py: 1,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          flexShrink: 0,
+        }}
+      >
+        <Typography variant="subtitle2" fontWeight={700} sx={{ textTransform: 'capitalize' }}>
+          {label}
+        </Typography>
+        <Chip
+          label={count}
+          size="small"
+          sx={{
+            fontWeight: 700,
+            fontSize: '0.72rem',
+            height: 20,
+            bgcolor: count > 0 ? 'primary.main' : 'action.disabledBackground',
+            color: count > 0 ? 'primary.contrastText' : 'text.disabled',
+          }}
+        />
+      </Box>
+
+      {/* Scrollable card list */}
+      <Box
+        sx={{
+          flex: 1,
+          overflowY: 'auto',
+          px: 1,
+          py: 1,
+          '&::-webkit-scrollbar': { width: 4 },
+          '&::-webkit-scrollbar-thumb': { bgcolor: 'divider', borderRadius: 2 },
+        }}
+      >
+        {sorted.length === 0 ? (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              py: 4,
+              opacity: 0.3,
+            }}
+          >
+            <SmartToyOutlinedIcon sx={{ fontSize: 32, mb: 1 }} />
+            <Typography variant="caption" color="text.disabled">
+              No runs
+            </Typography>
+          </Box>
+        ) : (
+          sorted.map((run) => {
+            const runChildren = childMap.get(run.id) ?? [];
+            return (
+              <AgentKanbanCard
+                key={run.id}
+                run={run}
+                children={runChildren}
+                onAction={onAction}
+              />
+            );
+          })
+        )}
+      </Box>
+    </Paper>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Kanban board view to the Agent Monitor page (`/agents`), togglable from the existing list view.

## What's new

### View toggle
- List / Board toggle in the page header (next to Refresh button)
- Uses MUI `ToggleButtonGroup` with `ViewListIcon` and `DashboardIcon`
- Selection persisted in `localStorage` key `agents-view-mode`

### Board view
- Second toggle for grouping dimension: **By Status** or **By Agent**
- Grouping persisted in `localStorage` key `agents-board-group`
- Horizontal scroll when columns overflow
- Status column order: `spawned` → `running` → `waiting` → `done` → `failed` → `timed_out` → `killed`
- Agent column order: `riff` → `arc` → `axel` → `torque` → `clutch`

### Kanban cards
- Agent badge + status badge
- Brief truncated to 2 lines
- Elapsed time + last heartbeat (red if stale on active run)
- Spawned by + Slack channel
- Expandable output (reuses `OutputPanel`)
- Kill / Restart action buttons (feature-flagged, same logic as list)
- Child runs rendered as indented sub-cards inside the parent card

### Columns
- Header with label + count badge
- Cards sorted newest first
- Empty columns show subtle empty state
- Max height fills viewport minus header; overflows scroll within column

## New components
- `src/components/agents/AgentKanbanBoard.tsx`
- `src/components/agents/AgentKanbanColumn.tsx`
- `src/components/agents/AgentKanbanCard.tsx`

## Constraints met
- ✅ List view completely unchanged
- ✅ No new dependencies
- ✅ TypeScript compiles clean (only pre-existing `knowledge-base/route.ts` error remains)
- ✅ Only touches `src/app/(dashboard)/agents/` and `src/components/agents/`