### PR TITLE
fix: contain horizontal overflow to kanban board only

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -108,7 +108,7 @@ function AgentsPageInner() {
 
   return (
     <PageTransition>
-      <Box sx={{ p: 3, maxWidth: viewMode === 'board' ? 'none' : 1200, mx: 'auto' }}>
+      <Box sx={{ p: 3, maxWidth: viewMode === 'board' ? 'none' : 1200, mx: 'auto', overflow: 'hidden' }}>
         {/* Header */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
           <SmartToyOutlinedIcon sx={{ fontSize: 32, color: 'primary.main' }} />


### PR DESCRIPTION
## Bug
Page-level horizontal scroll when in board view — the whole viewport scrolled instead of just the board columns.

## Fix
Added `overflow: 'hidden'` to the outer page container. The board's own `overflowX: 'auto'` still handles column scroll internally, but it no longer bleeds out to the page level.