### PR TITLE
fix: simplify agent monitor status filter — Active/Done/Failed/Killed only

### DIFF
--- a/src/components/agents/AgentFilterBar.tsx
+++ b/src/components/agents/AgentFilterBar.tsx
@@ -12,12 +12,9 @@ import type { AgentRunFilters } from '@/types/agent-run';
 
 const STATUS_OPTIONS = [
   { value: '', label: 'All statuses' },
-  { value: 'spawned', label: 'Spawned' },
-  { value: 'running', label: 'Running' },
-  { value: 'waiting', label: 'Waiting' },
+  { value: 'active', label: 'Active' },
   { value: 'done', label: 'Done' },
   { value: 'failed', label: 'Failed' },
-  { value: 'timed_out', label: 'Timed Out' },
   { value: 'killed', label: 'Killed' },
 ];
 

--- a/src/hooks/useAgentRuns.ts
+++ b/src/hooks/useAgentRuns.ts
@@ -10,7 +10,12 @@ const IDLE_INTERVAL_MS = 30_000;
 
 function buildUrl(filters: AgentRunFilters): string {
   const params = new URLSearchParams();
-  if (filters.status) params.set('status', filters.status);
+  if (filters.status) {
+    const statusValue = filters.status === 'active'
+      ? 'spawned,running,waiting'
+      : filters.status;
+    params.set('status', statusValue);
+  }
   if (filters.agent) params.set('agent', filters.agent);
   if (filters.projectTag) params.set('projectTag', filters.projectTag);
   if (filters.includeArchived) params.set('includeArchived', 'true');


### PR DESCRIPTION
Replaces the 7-option status filter (Spawned/Running/Waiting/Done/Failed/Timed Out/Killed) with 4 meaningful options:

- **Active** — expands to spawned,running,waiting on the API call (these are never independently set today)
- **Done**
- **Failed**
- **Killed**

Running, Waiting, and Timed Out are not reliably set by anything in the current pipeline so they just added noise.