### PR TITLE
feat: enrich agent runs with task detail fields (replaces FullThrottle tracking)

### DIFF
--- a/src/app/(dashboard)/agents/RunDetailDrawer.tsx
+++ b/src/app/(dashboard)/agents/RunDetailDrawer.tsx
@@ -37,9 +37,9 @@ interface ChildRun {
   id: string;
   agent: AgentName;
   brief: string;
-  task_title: string | null;
+  taskTitle: string | null;
   status: AgentRunStatus;
-  started_at: string;
+  startedAt: string;
 }
 
 interface RunNote {
@@ -54,22 +54,22 @@ interface RunDetail {
   id: string;
   agent: AgentName;
   brief: string;
-  task_title: string | null;
-  task_description: string | null;
-  expected_outcome: string | null;
+  taskTitle: string | null;
+  taskDescription: string | null;
+  expectedOutcome: string | null;
   status: AgentRunStatus;
-  session_key: string;
-  spawned_by: string;
-  slack_channel: string | null;
-  slack_thread_ts: string | null;
-  project_tag: string | null;
-  started_at: string;
-  last_heartbeat: string | null;
-  ended_at: string | null;
-  output_tail: string | null;
-  output_truncated: boolean;
-  parent_run_id: string | null;
-  archived_at: string | null;
+  sessionKey: string;
+  spawnedBy: string;
+  slackChannel: string | null;
+  slackThreadTs: string | null;
+  projectTag: string | null;
+  startedAt: string;
+  lastHeartbeat: string | null;
+  endedAt: string | null;
+  outputTail: string | null;
+  outputTruncated: boolean;
+  parentRunId: string | null;
+  archivedAt: string | null;
   children: ChildRun[];
   notes: RunNote[];
 }
@@ -173,17 +173,17 @@ export default function RunDetailDrawer({ runId, onClose, onOpenRun }: Props) {
   // Build timeline steps
   const timelineSteps: { label: string; ts: string | null }[] = [];
   if (run) {
-    timelineSteps.push({ label: 'Spawned', ts: run.started_at });
+    timelineSteps.push({ label: 'Spawned', ts: run.startedAt });
     if (run.status !== 'spawned') {
-      timelineSteps.push({ label: 'Running', ts: run.last_heartbeat });
+      timelineSteps.push({ label: 'Running', ts: run.lastHeartbeat });
     }
-    if (run.ended_at) {
+    if (run.endedAt) {
       const label = run.status === 'done' ? 'Done'
         : run.status === 'failed' ? 'Failed'
         : run.status === 'killed' ? 'Killed'
         : run.status === 'timed_out' ? 'Timed Out'
         : run.status;
-      timelineSteps.push({ label, ts: run.ended_at });
+      timelineSteps.push({ label, ts: run.endedAt });
     }
   }
 
@@ -220,7 +220,7 @@ export default function RunDetailDrawer({ runId, onClose, onOpenRun }: Props) {
                 variant="subtitle1"
                 sx={{ color: '#f1f5f9', fontWeight: 600, wordBreak: 'break-word' }}
               >
-                {run.task_title || run.brief}
+                {run.taskTitle || run.brief}
               </Typography>
               <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
                 <Chip
@@ -276,31 +276,31 @@ export default function RunDetailDrawer({ runId, onClose, onOpenRun }: Props) {
           <>
             {/* Meta row */}
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, mb: 2.5 }}>
-              <MetaRow label="Spawned by" value={run.spawned_by} />
-              {run.project_tag && <MetaRow label="Project" value={run.project_tag} />}
-              {run.session_key && <MetaRow label="Session" value={run.session_key} />}
+              <MetaRow label="Spawned by" value={run.spawnedBy} />
+              {run.projectTag && <MetaRow label="Project" value={run.projectTag} />}
+              {run.sessionKey && <MetaRow label="Session" value={run.sessionKey} />}
             </Box>
 
             <Divider sx={{ borderColor: '#ffffff11', mb: 2.5 }} />
 
             {/* Timestamps */}
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, mb: 2.5 }}>
-              <MetaRow label="Started" value={formatTs(run.started_at)} />
-              {run.ended_at && <MetaRow label="Ended" value={formatTs(run.ended_at)} />}
-              {run.last_heartbeat && (
-                <MetaRow label="Last heartbeat" value={formatTs(run.last_heartbeat)} />
+              <MetaRow label="Started" value={formatTs(run.startedAt)} />
+              {run.endedAt && <MetaRow label="Ended" value={formatTs(run.endedAt)} />}
+              {run.lastHeartbeat && (
+                <MetaRow label="Last heartbeat" value={formatTs(run.lastHeartbeat)} />
               )}
             </Box>
 
             {/* Slack link */}
-            {run.slack_channel && run.slack_thread_ts && (
+            {run.slackChannel && run.slackThreadTs && (
               <Box sx={{ mb: 2.5 }}>
                 <Button
                   size="small"
                   variant="outlined"
                   endIcon={<OpenInNewIcon fontSize="small" />}
                   component="a"
-                  href={`https://slack.com/archives/${run.slack_channel}/p${run.slack_thread_ts.replace('.', '')}`}
+                  href={`https://slack.com/archives/${run.slackChannel}/p${run.slackThreadTs.replace('.', '')}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   sx={{ borderColor: '#ffffff22', color: '#94a3b8', fontSize: '0.7rem' }}
@@ -342,39 +342,39 @@ export default function RunDetailDrawer({ runId, onClose, onOpenRun }: Props) {
             </Stepper>
 
             {/* task_description */}
-            {run.task_description && (
+            {run.taskDescription && (
               <>
                 <Divider sx={{ borderColor: '#ffffff11', mb: 2 }} />
                 <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 1, display: 'block', mb: 1 }}>
                   Task Description
                 </Typography>
                 <Typography variant="body2" sx={{ color: '#94a3b8', lineHeight: 1.7 }}>
-                  {run.task_description}
+                  {run.taskDescription}
                 </Typography>
               </>
             )}
 
             {/* expected_outcome */}
-            {run.expected_outcome && (
+            {run.expectedOutcome && (
               <>
                 <Divider sx={{ borderColor: '#ffffff11', my: 2 }} />
                 <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 1, display: 'block', mb: 1 }}>
                   Expected Outcome
                 </Typography>
                 <Typography variant="body2" sx={{ color: '#94a3b8', lineHeight: 1.7 }}>
-                  {run.expected_outcome}
+                  {run.expectedOutcome}
                 </Typography>
               </>
             )}
 
             {/* Output */}
-            {run.output_tail && (
+            {run.outputTail && (
               <>
                 <Divider sx={{ borderColor: '#ffffff11', my: 2 }} />
                 <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 1, display: 'block', mb: 1 }}>
                   Output
                 </Typography>
-                {run.output_truncated && (
+                {run.outputTruncated && (
                   <Alert
                     severity="warning"
                     sx={{ mb: 1, py: 0.25, '& .MuiAlert-message': { fontSize: '0.7rem' } }}
@@ -404,14 +404,14 @@ export default function RunDetailDrawer({ runId, onClose, onOpenRun }: Props) {
                       m: 0,
                     }}
                   >
-                    {run.output_tail}
+                    {run.outputTail}
                   </Typography>
                 </Box>
               </>
             )}
 
             {/* Parent run */}
-            {run.parent_run_id && (
+            {run.parentRunId && (
               <>
                 <Divider sx={{ borderColor: '#ffffff11', my: 2 }} />
                 <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 1, display: 'block', mb: 1 }}>
@@ -420,7 +420,7 @@ export default function RunDetailDrawer({ runId, onClose, onOpenRun }: Props) {
                 <Button
                   size="small"
                   variant="outlined"
-                  onClick={() => onOpenRun(run.parent_run_id!)}
+                  onClick={() => onOpenRun(run.parentRunId!)}
                   sx={{ borderColor: '#ffffff22', color: '#94a3b8', fontSize: '0.7rem' }}
                 >
                   View Parent Run
@@ -484,7 +484,7 @@ export default function RunDetailDrawer({ runId, onClose, onOpenRun }: Props) {
                           whiteSpace: 'nowrap',
                         }}
                       >
-                        {child.task_title || child.brief}
+                        {child.taskTitle || child.brief}
                       </Typography>
                     </Box>
                   ))}

--- a/src/app/api/agent-runs/[id]/route.ts
+++ b/src/app/api/agent-runs/[id]/route.ts
@@ -6,6 +6,43 @@ interface RouteContext {
   params: Promise<{ id: string }>;
 }
 
+// GET /api/agent-runs/:id — fetch single run with children and notes
+export async function GET(_request: Request, context: RouteContext) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  const { id } = await context.params;
+
+  const { data: run, error } = await supabase
+    .from('agent_runs')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error || !run) return notFound('Agent run');
+
+  // Fetch child runs
+  const { data: children } = await supabase
+    .from('agent_runs')
+    .select('id, agent, brief, task_title, status, started_at')
+    .eq('parent_run_id', id)
+    .order('started_at', { ascending: true });
+
+  // Fetch notes
+  const { data: notes } = await supabase
+    .from('run_notes')
+    .select('*')
+    .eq('run_id', id)
+    .order('created_at', { ascending: true });
+
+  return NextResponse.json({
+    ...toRunResponse(run),
+    children: children ?? [],
+    notes: notes ?? [],
+  });
+}
+
 // PATCH /api/agent-runs/:id — lifecycle updates and heartbeats
 export async function PATCH(request: Request, context: RouteContext) {
   const auth = await withAgentAuth();
@@ -69,7 +106,6 @@ export async function PATCH(request: Request, context: RouteContext) {
   if (endedAt !== undefined) updatePayload.ended_at = endedAt;
 
   // Atomic UPDATE with stale-heartbeat guard and terminal-state guard
-  // Build WHERE conditions using supabase filters (service client, so RLS bypassed)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let query = (supabase as any)
     .from('agent_runs')
@@ -123,6 +159,9 @@ function toRunResponse(r: any) {
     id: r.id,
     agent: r.agent,
     brief: r.brief,
+    taskTitle: r.task_title ?? null,
+    taskDescription: r.task_description ?? null,
+    expectedOutcome: r.expected_outcome ?? null,
     status: r.status,
     sessionKey: r.session_key,
     spawnedBy: r.spawned_by,

--- a/src/app/api/agent-runs/route.ts
+++ b/src/app/api/agent-runs/route.ts
@@ -28,6 +28,9 @@ export async function POST(request: Request) {
     projectTag,
     startedAt,
     parentRunId,
+    taskTitle,
+    taskDescription,
+    expectedOutcome,
   } = parsed.data;
 
   // Verify parentRunId exists if supplied
@@ -59,6 +62,9 @@ export async function POST(request: Request) {
       started_at: startedAt,
       parent_run_id: parentRunId ?? null,
       output_truncated: false,
+      task_title: taskTitle ?? null,
+      task_description: taskDescription ?? null,
+      expected_outcome: expectedOutcome ?? null,
     })
     .select()
     .single();
@@ -154,6 +160,9 @@ function toRunResponse(r: any) {
     id: r.id,
     agent: r.agent,
     brief: r.brief,
+    taskTitle: r.task_title ?? null,
+    taskDescription: r.task_description ?? null,
+    expectedOutcome: r.expected_outcome ?? null,
     status: r.status,
     sessionKey: r.session_key,
     spawnedBy: r.spawned_by,

--- a/src/components/agents/AgentFilterBar.tsx
+++ b/src/components/agents/AgentFilterBar.tsx
@@ -12,12 +12,9 @@ import type { AgentRunFilters } from '@/types/agent-run';
 
 const STATUS_OPTIONS = [
   { value: '', label: 'All statuses' },
-  { value: 'spawned', label: 'Spawned' },
-  { value: 'running', label: 'Running' },
-  { value: 'waiting', label: 'Waiting' },
+  { value: 'active', label: 'Active' },
   { value: 'done', label: 'Done' },
   { value: 'failed', label: 'Failed' },
-  { value: 'timed_out', label: 'Timed Out' },
   { value: 'killed', label: 'Killed' },
 ];
 

--- a/src/components/agents/AgentKanbanBoard.tsx
+++ b/src/components/agents/AgentKanbanBoard.tsx
@@ -11,25 +11,26 @@ import type { AgentRun, AgentRunStatus, AgentName } from '@/types/agent-run';
 
 export type BoardGrouping = 'status' | 'agent';
 
-const STATUS_COLUMNS: AgentRunStatus[] = [
-  'spawned',
-  'running',
-  'waiting',
+// Active groups spawned/running/waiting into one column since only spawned is reliably set today
+const STATUS_COLUMNS: Array<AgentRunStatus | 'active'> = [
+  'active',
   'done',
   'failed',
-  'timed_out',
   'killed',
 ];
 
-const STATUS_LABELS: Record<AgentRunStatus, string> = {
-  spawned: 'Spawned',
-  running: 'Running',
-  waiting: 'Waiting',
+const STATUS_LABELS: Record<AgentRunStatus | 'active', string> = {
+  active: 'Active',
+  spawned: 'Active',
+  running: 'Active',
+  waiting: 'Active',
   done: 'Done',
   failed: 'Failed',
-  timed_out: 'Timed Out',
+  timed_out: 'Failed',
   killed: 'Killed',
 };
+
+const ACTIVE_STATUSES = new Set<AgentRunStatus>(['spawned', 'running', 'waiting']);
 
 const AGENT_COLUMNS: AgentName[] = ['riff', 'arc', 'axel', 'torque', 'clutch'];
 
@@ -65,10 +66,14 @@ export default function AgentKanbanBoard({
 
   const columns =
     grouping === 'status'
-      ? STATUS_COLUMNS.map((status) => ({
-          key: status,
-          label: STATUS_LABELS[status],
-          runs: topLevel.filter((r) => r.status === status),
+      ? STATUS_COLUMNS.map((col) => ({
+          key: col,
+          label: STATUS_LABELS[col],
+          runs: col === 'active'
+            ? topLevel.filter((r) => ACTIVE_STATUSES.has(r.status))
+            : col === 'failed'
+              ? topLevel.filter((r) => r.status === 'failed' || r.status === 'timed_out')
+              : topLevel.filter((r) => r.status === col),
         }))
       : AGENT_COLUMNS.map((agent) => ({
           key: agent,

--- a/src/hooks/useAgentRuns.ts
+++ b/src/hooks/useAgentRuns.ts
@@ -10,7 +10,12 @@ const IDLE_INTERVAL_MS = 30_000;
 
 function buildUrl(filters: AgentRunFilters): string {
   const params = new URLSearchParams();
-  if (filters.status) params.set('status', filters.status);
+  if (filters.status) {
+    const statusValue = filters.status === 'active'
+      ? 'spawned,running,waiting'
+      : filters.status;
+    params.set('status', statusValue);
+  }
   if (filters.agent) params.set('agent', filters.agent);
   if (filters.projectTag) params.set('projectTag', filters.projectTag);
   if (filters.includeArchived) params.set('includeArchived', 'true');

--- a/src/lib/validations/agent-run.ts
+++ b/src/lib/validations/agent-run.ts
@@ -16,6 +16,10 @@ export const CreateRunSchema = z.object({
   projectTag: z.string().max(64).optional(),
   startedAt: z.string().datetime(),
   parentRunId: z.string().uuid().optional().nullable(),
+  // Task detail fields (replaces FullThrottle task tracking)
+  taskTitle: z.string().max(256).optional().nullable(),
+  taskDescription: z.string().optional().nullable(),
+  expectedOutcome: z.string().optional().nullable(),
 });
 
 export const PatchRunSchema = z

--- a/src/types/agent-run.ts
+++ b/src/types/agent-run.ts
@@ -13,6 +13,9 @@ export interface AgentRun {
   id: string;
   agent: AgentName;
   brief: string;
+  taskTitle: string | null;
+  taskDescription: string | null;
+  expectedOutcome: string | null;
   status: AgentRunStatus;
   sessionKey: string;
   spawnedBy: string;


### PR DESCRIPTION
## What
- Adds taskTitle, taskDescription, expectedOutcome fields to the agent runs API
- Adds missing GET /api/agent-runs/:id handler (with children + notes)
- Fixes RunDetailDrawer to use camelCase API response fields
- DB columns already exist via migration 00035

## Why
Replaces FullThrottle task tracking. TCM agent monitor run card is now the source of truth for what each agent was asked to do. Clutch will populate these fields on every spawn.