### PR TITLE
chore: sync dev into main — permalink (#88), Scout agent, display_id fix (#87)

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/suites/[suiteId]/page.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/suites/[suiteId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useState, useEffect, useCallback, useRef, useMemo, Suspense } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -34,9 +34,10 @@ interface ColumnConfig {
   columnVisibility?: Record<string, boolean>;
 }
 
-export default function SuiteViewPage() {
+function SuiteViewPageInner() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const projectId = params.projectId as string;
   const suiteId = params.suiteId as string;
   const { can, isLoading: authLoading } = useAuth();
@@ -222,10 +223,30 @@ export default function SuiteViewPage() {
     fetchTestCases();
   }, [selectedRunId, fetchTestCases]);
 
+  // Permalink: read ?case= on mount after data load completes.
+  const permalinkHandled = useRef(false);
+  useEffect(() => {
+    if (loading || permalinkHandled.current) return;
+    const caseId = searchParams.get('case');
+    if (!caseId) return;
+    permalinkHandled.current = true;
+    // Validate: case must exist in the loaded suite and belong to this suiteId
+    const match = testCases.find((tc) => tc.id === caseId && tc.suite_id === suiteId);
+    if (!match) {
+      // Silently drop invalid / cross-suite / soft-deleted param
+      router.replace(`/projects/${projectId}/suites/${suiteId}`, { scroll: false });
+      return;
+    }
+    setDrawerTestCaseId(caseId);
+    setCreateMode(false);
+    setDrawerOpen(true);
+  }, [loading, searchParams, testCases, projectId, suiteId, router]);
+
   const handleRowClick = (tc: TestCaseRow) => {
     setDrawerTestCaseId(tc.id);
     setCreateMode(false);
     setDrawerOpen(true);
+    router.replace(`/projects/${projectId}/suites/${suiteId}?case=${tc.id}`, { scroll: false });
   };
 
   const handleCreate = () => {
@@ -238,6 +259,7 @@ export default function SuiteViewPage() {
     setDrawerOpen(false);
     setDrawerTestCaseId(null);
     setCreateMode(false);
+    router.replace(`/projects/${projectId}/suites/${suiteId}`, { scroll: false });
   };
 
   const handleSaved = () => {
@@ -589,5 +611,19 @@ export default function SuiteViewPage() {
         />
       </Box>
     </PageTransition>
+  );
+}
+
+export default function SuiteViewPage() {
+  return (
+    <Suspense
+      fallback={
+        <Box sx={{ display: 'flex', justifyContent: 'center', pt: 8 }}>
+          <CircularProgress />
+        </Box>
+      }
+    >
+      <SuiteViewPageInner />
+    </Suspense>
   );
 }

--- a/src/components/test-cases/TestCaseDrawer.tsx
+++ b/src/components/test-cases/TestCaseDrawer.tsx
@@ -25,6 +25,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import LockIcon from '@mui/icons-material/Lock';
 import EditIcon from '@mui/icons-material/Edit';
+import LinkIcon from '@mui/icons-material/Link';
 import { alpha } from '@mui/material/styles';
 import { palette } from '@/theme/palette';
 import StepEditor, { type StepData } from './StepEditor';
@@ -105,6 +106,7 @@ export default function TestCaseDrawer({
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [linkCopied, setLinkCopied] = useState(false);
   const [trashDialogOpen, setTrashDialogOpen] = useState(false);
   const [trashWarning, setTrashWarning] = useState<string | null>(null);
 
@@ -359,6 +361,17 @@ export default function TestCaseDrawer({
     }
   };
 
+  const handleCopyLink = () => {
+    if (!testCaseId || !projectId) return;
+    const url = `${window.location.origin}/projects/${projectId}/suites/${suiteId}?case=${testCaseId}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    }).catch(() => {
+      // Clipboard unavailable — silently ignore
+    });
+  };
+
   const handlePlatformToggle = (platform: Platform) => {
     setPlatformTags((prev) =>
       prev.includes(platform)
@@ -429,6 +442,13 @@ export default function TestCaseDrawer({
             <Typography variant="h6" sx={{ flex: 1, fontWeight: 600 }}>
               {createMode ? 'New Test Case' : title || 'Test Case'}
             </Typography>
+            {!createMode && testCaseId && (
+              <Tooltip title={linkCopied ? 'Link copied!' : 'Copy link'}>
+                <IconButton onClick={handleCopyLink} size="small" sx={{ color: linkCopied ? 'success.main' : 'text.secondary' }}>
+                  <LinkIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            )}
             <IconButton onClick={onClose} size="small">
               <CloseIcon />
             </IconButton>


### PR DESCRIPTION
## What's in this merge

### feat: shareable test case permalink (#88)
- `?case=[caseId]` URL param on suite page auto-opens test case drawer
- Drawer open updates URL via `router.replace` (no history pollution)
- Copy Link icon button in drawer header with 2s 'Link copied!' tooltip
- Invalid/cross-suite/missing params silently dropped
- Auth scope: authenticated users only

### feat: Scout agent additions
- Scout added to agent_name enum, agent registry, badge, filter, and kanban board
- Migration 00037

### fix: partial display_id unique index (#87)
- Replaced display_id unique constraint with partial index for active rows only
- Migration 00038

## Auth scope note
Permalink is authenticated-only. Unauthenticated users hit the existing login redirect. No returnTo mechanism included per Spencer's scope decision 2026-06-01.