### PR TITLE
feat: add run_type field for Clutch orchestrator self-registration (Migration 00039)

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -72,11 +72,13 @@ function AgentsPageInner() {
     status: searchParams.get('status') ?? undefined,
     projectTag: searchParams.get('projectTag') ?? undefined,
     includeArchived: searchParams.get('includeArchived') === 'true',
+    runType: (searchParams.get('runType') as AgentRunFilters['runType']) ?? undefined,
   }), [
     searchParams.get('agent'),
     searchParams.get('status'),
     searchParams.get('projectTag'),
     searchParams.get('includeArchived'),
+    searchParams.get('runType'),
   ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { runs, total, loading, error, refresh } = useAgentRuns(filters);
@@ -91,6 +93,7 @@ function AgentsPageInner() {
     if (next.status) params.set('status', next.status);
     if (next.projectTag) params.set('projectTag', next.projectTag);
     if (next.includeArchived) params.set('includeArchived', 'true');
+    if (next.runType) params.set('runType', next.runType);
     router.push(`/agents${params.toString() ? `?${params.toString()}` : ''}`);
   }
 

--- a/src/app/api/agent-runs/[id]/route.ts
+++ b/src/app/api/agent-runs/[id]/route.ts
@@ -163,6 +163,7 @@ function toRunResponse(r: any) {
     taskDescription: r.task_description ?? null,
     expectedOutcome: r.expected_outcome ?? null,
     status: r.status,
+    runType: r.run_type ?? 'subagent',
     sessionKey: r.session_key,
     spawnedBy: r.spawned_by,
     slackChannel: r.slack_channel,

--- a/src/app/api/agent-runs/route.ts
+++ b/src/app/api/agent-runs/route.ts
@@ -31,6 +31,7 @@ export async function POST(request: Request) {
     taskTitle,
     taskDescription,
     expectedOutcome,
+    runType,
   } = parsed.data;
 
   // Verify parentRunId exists if supplied
@@ -65,6 +66,7 @@ export async function POST(request: Request) {
       task_title: taskTitle ?? null,
       task_description: taskDescription ?? null,
       expected_outcome: expectedOutcome ?? null,
+      run_type: runType,
     })
     .select()
     .single();
@@ -94,6 +96,8 @@ export async function GET(request: Request) {
   const agentParam = searchParams.get('agent');
   const projectTag = searchParams.get('projectTag');
   const parentRunId = searchParams.get('parentRunId');
+  const runTypeParam = searchParams.get('runType');
+  const sessionKeyParam = searchParams.get('sessionKey');
   const includeArchived = searchParams.get('includeArchived') === 'true';
   const limit = Math.min(parseInt(searchParams.get('limit') ?? '100', 10), 100);
   const offset = parseInt(searchParams.get('offset') ?? '0', 10);
@@ -123,6 +127,12 @@ export async function GET(request: Request) {
   }
   if (parentRunId) {
     query = query.eq('parent_run_id', parentRunId);
+  }
+  if (runTypeParam) {
+    query = query.eq('run_type', runTypeParam);
+  }
+  if (sessionKeyParam) {
+    query = query.eq('session_key', sessionKeyParam);
   }
 
   const { data: runs, error, count } = await query;
@@ -164,6 +174,7 @@ function toRunResponse(r: any) {
     taskDescription: r.task_description ?? null,
     expectedOutcome: r.expected_outcome ?? null,
     status: r.status,
+    runType: r.run_type ?? 'subagent',
     sessionKey: r.session_key,
     spawnedBy: r.spawned_by,
     slackChannel: r.slack_channel,

--- a/src/components/agents/AgentFilterBar.tsx
+++ b/src/components/agents/AgentFilterBar.tsx
@@ -28,6 +28,12 @@ const AGENT_OPTIONS = [
   { value: 'scout', label: 'Scout' },
 ];
 
+const RUN_TYPE_OPTIONS = [
+  { value: '', label: 'All types' },
+  { value: 'subagent', label: 'Subagent' },
+  { value: 'orchestrator', label: 'Orchestrator' },
+];
+
 interface Props {
   filters: AgentRunFilters;
   onChange: (filters: AgentRunFilters) => void;
@@ -70,6 +76,19 @@ export default function AgentFilterBar({ filters, onChange }: Props) {
         sx={{ minWidth: 150 }}
         placeholder="e.g. fullthrottle"
       />
+
+      <FormControl size="small" sx={{ minWidth: 160 }}>
+        <InputLabel>Run type</InputLabel>
+        <Select
+          value={filters.runType ?? ''}
+          label="Run type"
+          onChange={(e) => onChange({ ...filters, runType: (e.target.value || undefined) as typeof filters.runType })}
+        >
+          {RUN_TYPE_OPTIONS.map((o) => (
+            <MenuItem key={o.value} value={o.value}>{o.label}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
 
       <FormControlLabel
         control={

--- a/src/components/agents/AgentKanbanCard.tsx
+++ b/src/components/agents/AgentKanbanCard.tsx
@@ -23,6 +23,7 @@ import AgentStatusBadge from './AgentStatusBadge';
 import ElapsedTime from './ElapsedTime';
 import HeartbeatCell from './HeartbeatCell';
 import OutputPanel from './OutputPanel';
+import OrchestratorBadge from './OrchestratorBadge';
 import type { AgentRun } from '@/types/agent-run';
 
 const TERMINAL_STATUSES = new Set(['done', 'failed', 'timed_out', 'killed']);
@@ -99,6 +100,7 @@ export default function AgentKanbanCard({ run, children = [], isChild = false, o
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap', mb: 0.75 }}>
           <AgentBadge agent={run.agent} />
           <AgentStatusBadge status={run.status} />
+          <OrchestratorBadge runType={run.runType ?? 'subagent'} />
         </Box>
 
         {/* Brief (2-line clamp) */}

--- a/src/components/agents/AgentRunRow.tsx
+++ b/src/components/agents/AgentRunRow.tsx
@@ -19,6 +19,7 @@ import AgentBadge from './AgentBadge';
 import ElapsedTime from './ElapsedTime';
 import HeartbeatCell from './HeartbeatCell';
 import OutputPanel from './OutputPanel';
+import OrchestratorBadge from './OrchestratorBadge';
 import type { AgentRun } from '@/types/agent-run';
 
 const TERMINAL_STATUSES = new Set(['done', 'failed', 'timed_out', 'killed']);
@@ -91,6 +92,7 @@ export default function AgentRunRow({ run, isChild = false, isOrphan = false, on
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, flexWrap: 'wrap' }}>
         <AgentBadge agent={run.agent} />
         <AgentStatusBadge status={run.status} />
+        <OrchestratorBadge runType={run.runType ?? 'subagent'} />
 
         {isOrphan && (
           <Typography variant="caption" color="text.disabled" sx={{ alignSelf: 'center' }}>

--- a/src/components/agents/OrchestratorBadge.tsx
+++ b/src/components/agents/OrchestratorBadge.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import type { AgentRunType } from '@/types/agent-run';
+
+interface Props {
+  runType: AgentRunType;
+  size?: 'small' | 'medium';
+}
+
+/**
+ * Subtle visual badge shown on kanban cards and list rows for orchestrator runs.
+ * Renders nothing for subagent runs (the default).
+ */
+export default function OrchestratorBadge({ runType, size = 'small' }: Props) {
+  if (runType !== 'orchestrator') return null;
+
+  return (
+    <Tooltip title="Orchestrator run — Clutch self-registered this turn" arrow>
+      <Chip
+        label="Orchestrator"
+        icon={<AutoAwesomeIcon sx={{ fontSize: '0.75rem !important' }} />}
+        size={size}
+        sx={{
+          height: size === 'small' ? 18 : 22,
+          fontSize: size === 'small' ? '0.6rem' : '0.7rem',
+          fontWeight: 600,
+          bgcolor: 'secondary.main',
+          color: 'secondary.contrastText',
+          letterSpacing: '0.02em',
+          '& .MuiChip-icon': {
+            color: 'secondary.contrastText',
+            ml: 0.5,
+          },
+          '& .MuiChip-label': {
+            px: 0.75,
+          },
+        }}
+      />
+    </Tooltip>
+  );
+}

--- a/src/hooks/useAgentRuns.ts
+++ b/src/hooks/useAgentRuns.ts
@@ -19,6 +19,7 @@ function buildUrl(filters: AgentRunFilters): string {
   if (filters.agent) params.set('agent', filters.agent);
   if (filters.projectTag) params.set('projectTag', filters.projectTag);
   if (filters.includeArchived) params.set('includeArchived', 'true');
+  if (filters.runType) params.set('runType', filters.runType);
   params.set('limit', '100');
   return `/api/agent-runs?${params.toString()}`;
 }

--- a/src/lib/validations/agent-run.ts
+++ b/src/lib/validations/agent-run.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const TERMINAL_STATUSES = ['done', 'failed', 'timed_out', 'killed'] as const;
 export const VALID_AGENTS = ['axel', 'riff', 'arc', 'torque', 'clutch', 'scout'] as const;
 export const VALID_STATUSES = ['spawned', 'running', 'waiting', 'done', 'failed', 'timed_out', 'killed'] as const;
+export const VALID_RUN_TYPES = ['subagent', 'orchestrator'] as const;
 
 export const OUTPUT_TAIL_MAX_BYTES = 65_536;
 
@@ -20,6 +21,8 @@ export const CreateRunSchema = z.object({
   taskTitle: z.string().max(256).optional().nullable(),
   taskDescription: z.string().optional().nullable(),
   expectedOutcome: z.string().optional().nullable(),
+  // Run type: 'subagent' (default) or 'orchestrator' (Clutch self-registration)
+  runType: z.enum(VALID_RUN_TYPES).optional().default('subagent'),
 });
 
 export const PatchRunSchema = z
@@ -33,5 +36,6 @@ export const PatchRunSchema = z
     message: 'Patch body must not be empty',
   });
 
+export type AgentRunType = typeof VALID_RUN_TYPES[number];
 export type CreateRunInput = z.infer<typeof CreateRunSchema>;
 export type PatchRunInput = z.infer<typeof PatchRunSchema>;

--- a/src/types/agent-run.ts
+++ b/src/types/agent-run.ts
@@ -9,6 +9,8 @@ export type AgentRunStatus =
 
 export type AgentName = 'axel' | 'riff' | 'arc' | 'torque' | 'clutch' | 'scout';
 
+export type AgentRunType = 'subagent' | 'orchestrator';
+
 export interface AgentRun {
   id: string;
   agent: AgentName;
@@ -17,6 +19,7 @@ export interface AgentRun {
   taskDescription: string | null;
   expectedOutcome: string | null;
   status: AgentRunStatus;
+  runType: AgentRunType;
   sessionKey: string;
   spawnedBy: string;
   slackChannel: string | null;
@@ -46,4 +49,5 @@ export interface AgentRunFilters {
   projectTag?: string;
   search?: string;
   includeArchived?: boolean;
+  runType?: AgentRunType | '';
 }

--- a/supabase/migrations/00039_agent_run_type.sql
+++ b/supabase/migrations/00039_agent_run_type.sql
@@ -1,0 +1,10 @@
+-- Migration 00039: Add run_type enum to agent_runs
+-- Distinguishes Clutch orchestrator runs from subagent runs.
+-- All existing rows default to 'subagent' with no backfill required.
+
+CREATE TYPE agent_run_type AS ENUM ('subagent', 'orchestrator');
+
+ALTER TABLE agent_runs
+  ADD COLUMN IF NOT EXISTS run_type agent_run_type NOT NULL DEFAULT 'subagent';
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_run_type ON agent_runs(run_type);


### PR DESCRIPTION
## Summary

Implements Task 1 from the Clutch self-registration spec (Option C per ARC brief 2026-06-03).

Adds a `run_type` column to `agent_runs` to distinguish Clutch orchestrator runs from subagent runs. All existing rows default to `'subagent'` — no backfill required.

---

## Changes

### Database
- **Migration 00039** (`supabase/migrations/00039_agent_run_type.sql`):
  - `CREATE TYPE agent_run_type AS ENUM ('subagent', 'orchestrator')`
  - `ALTER TABLE agent_runs ADD COLUMN run_type agent_run_type NOT NULL DEFAULT 'subagent'`
  - `CREATE INDEX idx_agent_runs_run_type`

### API
- **`POST /api/agent-runs`**: Accepts optional `runType?: 'subagent' | 'orchestrator'` (defaults to `'subagent'`). Stored as `run_type`. Returned in response.
- **`GET /api/agent-runs`**: 
  - New optional `runType` filter param (e.g. `?runType=orchestrator`)
  - New optional `sessionKey` filter param (needed for 409 conflict handling per ARC brief §4.2 — allows Clutch to fetch existing run ID when `SESSION_KEY_CONFLICT` is returned)
  - `runType` returned in all response objects
- Both `toRunResponse()` functions (main route + `[id]/route.ts`) updated

### Validation
- `CreateRunSchema`: adds `runType: z.enum(['subagent', 'orchestrator']).optional().default('subagent')`
- `VALID_RUN_TYPES` export added
- `AgentRunType` type exported from validations

### UI
- **`OrchestratorBadge`** (new component): Subtle chip badge (`AutoAwesome` icon + "Orchestrator" label, secondary color) shown on orchestrator runs. Renders nothing for subagent runs.
- **`AgentKanbanCard`**: Renders `OrchestratorBadge` in the badge row next to agent and status badges
- **`AgentRunRow`** (list view): Renders `OrchestratorBadge` in the header row
- **`AgentFilterBar`**: Adds a "Run type" dropdown (All / Subagent / Orchestrator)
- **`useAgentRuns` hook**: Passes `runType` filter to API URL
- **`agents/page.tsx`**: Reads/writes `runType` from URL search params

### Types
- `AgentRun` interface: adds `runType: AgentRunType`
- `AgentRunFilters` interface: adds `runType?: AgentRunType | ''`

---

## Task 2: Stale-run timeout cron ✅

Confirmed at `/api/cron/timeout-agent-runs` (also `/api/cron/agent-timeout` as secondary):
- Schedule: `*/2 * * * *` (every 2 minutes) via `vercel.json`
- Threshold: `AGENT_TIMEOUT_MINUTES` env var, defaults to 10
- Covers statuses: `spawned`, `running`, `waiting`
- Uses `COALESCE(last_heartbeat, started_at)` correctly
- **No changes needed** — logic is correct as-is.

---

## Notes for Spencer / ARC

- Session key granularity (one card per thread vs. one per reply) is still an open product decision per ARC brief §9.1
- The `sessionKey` GET filter directly enables Clutch's 409 conflict handling flow from ARC brief §4.2
- `parentRunId` hierarchy (Clutch run → child subagent runs) works already; no schema changes needed

Resolves: Axel Task 1 (Clutch self-registration schema + API + UI)