### PR TITLE
feat: Agent Monitor — Close Session button

### DIFF
--- a/src/app/api/agent-runs/[id]/close-session/route.ts
+++ b/src/app/api/agent-runs/[id]/close-session/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { withAgentAuth, notFound, serverError } from '@/lib/api/helpers';
+import { TERMINAL_STATUSES } from '@/lib/validations/agent-run';
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+// POST /api/agent-runs/:id/close-session
+// Operator-initiated: fires the OpenClaw cron wake endpoint with full run context
+// so the Clutch session can wrap up and close itself. Does NOT directly update
+// the run status — Clutch will PATCH the run to 'done' once it finishes.
+export async function POST(_request: Request, context: RouteContext) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  const { id } = await context.params;
+
+  // Fetch the run
+  const { data: run, error: fetchErr } = await supabase
+    .from('agent_runs')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (fetchErr || !run) return notFound('Agent run');
+
+  // Guard: only active runs can be closed
+  if (TERMINAL_STATUSES.includes(run.status as typeof TERMINAL_STATUSES[number])) {
+    return NextResponse.json(
+      { error: 'Run is already in a terminal state', code: 'ALREADY_TERMINAL' },
+      { status: 409 },
+    );
+  }
+
+  const wakeUrl = process.env.OPENCLAW_WAKE_URL;
+  const clutchKey = process.env.CLUTCH_API_KEY;
+
+  if (!wakeUrl) {
+    return NextResponse.json(
+      { error: 'OPENCLAW_WAKE_URL is not configured', code: 'NOT_CONFIGURED' },
+      { status: 503 },
+    );
+  }
+
+  // Build the webhook payload
+  const payload = {
+    runId: run.id,
+    sessionKey: run.session_key,
+    agent: run.agent,
+    brief: run.brief,
+    taskTitle: run.task_title ?? null,
+    taskDescription: run.task_description ?? null,
+    outputTail: run.output_tail ?? null,
+    slackChannel: run.slack_channel ?? null,
+    slackThreadTs: run.slack_thread_ts ?? null,
+    runType: run.run_type ?? 'subagent',
+  };
+
+  try {
+    const wakeRes = await fetch(wakeUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Clutch-Key': clutchKey ?? '',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!wakeRes.ok) {
+      const errorText = await wakeRes.text().catch(() => '');
+      console.error('[close-session] OpenClaw wake endpoint returned non-OK', wakeRes.status, errorText);
+      return NextResponse.json(
+        {
+          error: `OpenClaw wake endpoint returned ${wakeRes.status}`,
+          code: 'WAKE_FAILED',
+          detail: errorText,
+        },
+        { status: 502 },
+      );
+    }
+  } catch (err) {
+    console.error('[close-session] OpenClaw wake endpoint unreachable', err);
+    return serverError(err instanceof Error ? err.message : 'Failed to reach OpenClaw wake endpoint');
+  }
+
+  return NextResponse.json({ ok: true, runId: run.id });
+}

--- a/src/components/agents/AgentKanbanCard.tsx
+++ b/src/components/agents/AgentKanbanCard.tsx
@@ -16,6 +16,7 @@ import Alert from '@mui/material/Alert';
 import Tooltip from '@mui/material/Tooltip';
 import StopIcon from '@mui/icons-material/Stop';
 import ReplayIcon from '@mui/icons-material/Replay';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import AgentBadge from './AgentBadge';
@@ -42,6 +43,9 @@ export default function AgentKanbanCard({ run, children = [], isChild = false, o
   const [actionLoading, setActionLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [openClawWarning, setOpenClawWarning] = useState(false);
+  const [closeSessionLoading, setCloseSessionLoading] = useState(false);
+  const [closeSessionSent, setCloseSessionSent] = useState(false);
+  const [closeSessionError, setCloseSessionError] = useState<string | null>(null);
 
   const isActive = ACTIVE_STATUSES.has(run.status);
   const isTerminal = TERMINAL_STATUSES.has(run.status);
@@ -61,6 +65,21 @@ export default function AgentKanbanCard({ run, children = [], isChild = false, o
     } finally {
       setActionLoading(false);
       setKillDialogOpen(false);
+    }
+  }
+
+  async function handleCloseSession() {
+    setCloseSessionLoading(true);
+    setCloseSessionError(null);
+    try {
+      const res = await fetch(`/api/agent-runs/${run.id}/close-session`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Close session failed');
+      setCloseSessionSent(true);
+    } catch (err) {
+      setCloseSessionError(err instanceof Error ? err.message : 'Close session failed');
+    } finally {
+      setCloseSessionLoading(false);
     }
   }
 
@@ -151,6 +170,16 @@ export default function AgentKanbanCard({ run, children = [], isChild = false, o
             {actionError}
           </Alert>
         )}
+        {closeSessionError && (
+          <Alert severity="error" sx={{ mt: 1, py: 0 }} onClose={() => setCloseSessionError(null)}>
+            {closeSessionError}
+          </Alert>
+        )}
+        {closeSessionSent && (
+          <Alert severity="success" sx={{ mt: 1, py: 0 }} onClose={() => setCloseSessionSent(false)}>
+            Close signal sent — waiting for Clutch to wrap up.
+          </Alert>
+        )}
         {openClawWarning && (
           <Alert severity="warning" sx={{ mt: 1, py: 0 }} onClose={() => setOpenClawWarning(false)}>
             OpenClaw integration not active — DB record updated but session was not terminated remotely.
@@ -178,6 +207,23 @@ export default function AgentKanbanCard({ run, children = [], isChild = false, o
       {/* Action buttons */}
       {(isActive || isTerminal) && (
         <CardActions sx={{ px: 1.5, pt: 0, pb: 1 }}>
+          {isActive && (
+            <Tooltip title="Signal this session to close itself. Clutch will wrap up and mark the run done.">
+              <span>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="success"
+                  startIcon={<CheckCircleOutlineIcon />}
+                  onClick={handleCloseSession}
+                  disabled={closeSessionLoading || closeSessionSent}
+                  sx={{ textTransform: 'none', fontSize: '0.72rem' }}
+                >
+                  {closeSessionSent ? 'Closing…' : closeSessionLoading ? 'Sending…' : 'Close Session'}
+                </Button>
+              </span>
+            </Tooltip>
+          )}
           {isActive && (
             <Tooltip
               title={

--- a/src/components/agents/AgentRunRow.tsx
+++ b/src/components/agents/AgentRunRow.tsx
@@ -14,6 +14,7 @@ import DialogActions from '@mui/material/DialogActions';
 import Alert from '@mui/material/Alert';
 import StopIcon from '@mui/icons-material/Stop';
 import ReplayIcon from '@mui/icons-material/Replay';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import AgentStatusBadge from './AgentStatusBadge';
 import AgentBadge from './AgentBadge';
 import ElapsedTime from './ElapsedTime';
@@ -37,6 +38,9 @@ export default function AgentRunRow({ run, isChild = false, isOrphan = false, on
   const [actionLoading, setActionLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [openClawWarning, setOpenClawWarning] = useState(false);
+  const [closeSessionLoading, setCloseSessionLoading] = useState(false);
+  const [closeSessionSent, setCloseSessionSent] = useState(false);
+  const [closeSessionError, setCloseSessionError] = useState<string | null>(null);
 
   const isActive = ACTIVE_STATUSES.has(run.status);
   const isTerminal = TERMINAL_STATUSES.has(run.status);
@@ -57,6 +61,21 @@ export default function AgentRunRow({ run, isChild = false, isOrphan = false, on
     } finally {
       setActionLoading(false);
       setKillDialogOpen(false);
+    }
+  }
+
+  async function handleCloseSession() {
+    setCloseSessionLoading(true);
+    setCloseSessionError(null);
+    try {
+      const res = await fetch(`/api/agent-runs/${run.id}/close-session`, { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? 'Close session failed');
+      setCloseSessionSent(true);
+    } catch (err) {
+      setCloseSessionError(err instanceof Error ? err.message : 'Close session failed');
+    } finally {
+      setCloseSessionLoading(false);
     }
   }
 
@@ -163,9 +182,36 @@ export default function AgentRunRow({ run, isChild = false, isOrphan = false, on
           Agent may still be running — OpenClaw integration is not yet active. DB record updated, but the session was not terminated remotely.
         </Alert>
       )}
+      {closeSessionError && (
+        <Alert severity="error" sx={{ mt: 1 }} onClose={() => setCloseSessionError(null)}>
+          {closeSessionError}
+        </Alert>
+      )}
+      {closeSessionSent && (
+        <Alert severity="success" sx={{ mt: 1 }} onClose={() => setCloseSessionSent(false)}>
+          Close signal sent — waiting for Clutch to wrap up.
+        </Alert>
+      )}
 
       {/* Actions */}
       <Box sx={{ display: 'flex', gap: 1, mt: 1.5 }}>
+        {isActive && (
+          <Tooltip title="Signal this session to close itself. Clutch will wrap up and mark the run done.">
+            <span>
+              <Button
+                size="small"
+                variant="outlined"
+                color="success"
+                startIcon={<CheckCircleOutlineIcon />}
+                onClick={handleCloseSession}
+                disabled={closeSessionLoading || closeSessionSent}
+                sx={{ textTransform: 'none' }}
+              >
+                {closeSessionSent ? 'Closing…' : closeSessionLoading ? 'Sending…' : 'Close Session'}
+              </Button>
+            </span>
+          </Tooltip>
+        )}
         {isActive && (
           <Tooltip
             title={


### PR DESCRIPTION
## Summary

Adds a **Close Session** button to active run cards in the Agent Monitor (both Kanban and list views).

Closes #93

---

## What changed

### New API route — `POST /api/agent-runs/:id/close-session`
- Only callable on active runs (spawned/running/waiting); returns 409 if already terminal
- Fires the OpenClaw cron wake endpoint with the full run context payload (runId, sessionKey, agent, brief, taskTitle, taskDescription, outputTail, slackChannel, slackThreadTs, runType)
- Auth: `X-Clutch-Key: <CLUTCH_API_KEY>` header
- Target: `OPENCLAW_WAKE_URL` env var (placeholder added to `.env.local` with comment)
- Does **not** optimistically update run status — Clutch PATCHes the run to `done` when it wraps up

### `AgentKanbanCard.tsx`
- Close Session button (green, CheckCircleOutline icon) rendered on all active run cards
- Hidden/not rendered on terminal runs (done, failed, timed_out, killed)
- Button states: idle → Sending… (loading) → Closing… (disabled, sent)
- Inline success alert: "Close signal sent — waiting for Clutch to wrap up."
- Inline error alert with dismiss

### `AgentRunRow.tsx`
- Same Close Session button in the list/row view, same state machine

### `.env.local`
- Added `OPENCLAW_WAKE_URL=` placeholder with setup comment

---

## Webhook payload
```json
{
  "runId": "<uuid>",
  "sessionKey": "<string>",
  "agent": "<string>",
  "brief": "<string>",
  "taskTitle": "<string|null>",
  "taskDescription": "<string|null>",
  "outputTail": "<string|null>",
  "slackChannel": "<string|null>",
  "slackThreadTs": "<string|null>",
  "runType": "orchestrator|subagent"
}
```

---

## Testing
- Build passes: `npm run build` ✅ (no TypeScript errors, new route listed in output)
- `OPENCLAW_WAKE_URL` must be set for the button to function; if unset, route returns `503 NOT_CONFIGURED`
