### PR TITLE
feat(trash): Delete selected — permanently delete checked items from trash

### DIFF
--- a/src/app/api/test-cases/bulk/route.ts
+++ b/src/app/api/test-cases/bulk/route.ts
@@ -58,8 +58,9 @@ export async function POST(request: Request) {
 
   if (action === 'delete') return handleBulkDelete(request);
   if (action === 'restore') return handleBulkRestore(request);
+  if (action === 'hard_delete') return handleBulkHardDelete(request);
 
-  return NextResponse.json({ error: 'Unknown bulk action. Use ?action=delete or ?action=restore' }, { status: 400 });
+  return NextResponse.json({ error: 'Unknown bulk action. Use ?action=delete, ?action=restore, or ?action=hard_delete' }, { status: 400 });
 }
 
 async function handleBulkDelete(request: Request) {
@@ -126,6 +127,53 @@ async function handleBulkDelete(request: Request) {
   return NextResponse.json({
     deleted: toDelete,
     skipped: alreadyDeleted,
+    not_found: notFound,
+  });
+}
+
+/**
+ * Permanently deletes all supplied IDs from the trash (hard delete).
+ * IDs must already be soft-deleted (deleted_at IS NOT NULL).
+ * Automated (in_cicd) cases are included — caller is responsible for showing
+ * the appropriate confirmation UI before invoking this action.
+ *
+ * Response: { deleted: [], skipped: [], not_found: [] }
+ *   skipped = IDs that were NOT in the trash (still active — not touched)
+ *   not_found = IDs that don't exist at all
+ */
+async function handleBulkHardDelete(request: Request) {
+  const auth = await withAuth('soft_delete');
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth.ctx;
+
+  const body = await request.json();
+  const parsed = bulkIdsSchema.safeParse(body);
+  if (!parsed.success) return validationError(parsed.error.flatten());
+
+  const { ids } = parsed.data;
+
+  // Fetch all matching records regardless of deleted_at (UNFILTERED_SCOPE)
+  const { data: existing } = await supabase
+    .from('test_cases')
+    .select('id, deleted_at')
+    .in('id', ids);
+
+  const existingMap = new Map((existing ?? []).map((r: { id: string; deleted_at: string | null }) => [r.id, r]));
+  const notFound = ids.filter((id: string) => !existingMap.has(id));
+  const notInTrash = ids.filter((id: string) => existingMap.has(id) && !existingMap.get(id)?.deleted_at);
+  const toDelete = ids.filter((id: string) => existingMap.get(id)?.deleted_at);
+
+  if (toDelete.length > 0) {
+    await supabase
+      .from('test_cases')
+      .delete()
+      .in('id', toDelete)
+      .not('deleted_at', 'is', null); // guard: only touch trashed records
+  }
+
+  return NextResponse.json({
+    deleted: toDelete,
+    skipped: notInTrash,
     not_found: notFound,
   });
 }

--- a/src/components/test-cases/TrashView.tsx
+++ b/src/components/test-cases/TrashView.tsx
@@ -54,13 +54,17 @@ export default function TrashView({ suiteId }: TrashViewProps) {
   const [restoring, setRestoring] = useState<Set<string>>(new Set());
   const [deleting, setDeleting] = useState<Set<string>>(new Set());
 
-  // Initial hard delete confirmation dialog
+  // Individual hard delete confirmation dialog
   const [hardDeleteTarget, setHardDeleteTarget] = useState<DeletedTestCase | null>(null);
   const [hardDeletePending, setHardDeletePending] = useState(false);
 
   // Second-step CI/CD warning dialog (shown when API returns confirmation_required)
   const [cicdConfirmTarget, setCicdConfirmTarget] = useState<{ id: string; warning: string } | null>(null);
   const [cicdConfirmPending, setCicdConfirmPending] = useState(false);
+
+  // Delete All confirmation dialog
+  const [deleteAllOpen, setDeleteAllOpen] = useState(false);
+  const [deleteAllPending, setDeleteAllPending] = useState(false);
 
   const fetchDeleted = useCallback(async () => {
     setLoading(true);
@@ -117,6 +121,28 @@ export default function TrashView({ suiteId }: TrashViewProps) {
       }
     } finally {
       setRestoring(new Set());
+    }
+  };
+
+  const handleDeleteAll = async () => {
+    const ids = cases.map((c) => c.id);
+    if (ids.length === 0) return;
+    setDeleteAllPending(true);
+    try {
+      const res = await fetch('/api/test-cases/bulk?action=hard_delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids }),
+      });
+      if (res.ok) {
+        const result = await res.json();
+        const deletedSet = new Set<string>(result.deleted ?? []);
+        setCases((prev) => prev.filter((c) => !deletedSet.has(c.id)));
+        setSelected(new Set());
+        setDeleteAllOpen(false);
+      }
+    } finally {
+      setDeleteAllPending(false);
     }
   };
 
@@ -201,17 +227,30 @@ export default function TrashView({ suiteId }: TrashViewProps) {
           <Typography variant="h6" fontWeight={600}>Trash</Typography>
           <Typography variant="body2" color="text.secondary">({cases.length} item{cases.length !== 1 ? 's' : ''})</Typography>
         </Box>
-        {selected.size > 0 && (
-          <Button
-            startIcon={<RestoreIcon />}
-            variant="outlined"
-            color="primary"
-            onClick={handleBulkRestore}
-            disabled={restoring.size > 0}
-          >
-            Restore {selected.size} selected
-          </Button>
-        )}
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          {selected.size > 0 && (
+            <Button
+              startIcon={<RestoreIcon />}
+              variant="outlined"
+              color="primary"
+              onClick={handleBulkRestore}
+              disabled={restoring.size > 0}
+            >
+              Restore {selected.size} selected
+            </Button>
+          )}
+          {cases.length > 0 && (
+            <Button
+              startIcon={<DeleteForeverIcon />}
+              variant="outlined"
+              color="error"
+              onClick={() => setDeleteAllOpen(true)}
+              disabled={restoring.size > 0 || deleting.size > 0}
+            >
+              Delete All
+            </Button>
+          )}
+        </Box>
       </Box>
 
       {cases.length === 0 ? (
@@ -293,6 +332,41 @@ export default function TrashView({ suiteId }: TrashViewProps) {
           </Table>
         </TableContainer>
       )}
+
+      {/* Delete All confirmation dialog */}
+      <Dialog open={deleteAllOpen} onClose={() => setDeleteAllOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <DeleteForeverIcon color="error" />
+          Empty Trash
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" gutterBottom>
+            Permanently delete all <strong>{cases.length} item{cases.length !== 1 ? 's' : ''}</strong> in the trash?
+          </Typography>
+          <Alert severity="error" sx={{ mt: 1 }}>
+            This cannot be undone. All trashed test cases and their history will be permanently removed.
+          </Alert>
+          {cases.some((c) => c.automation_status === 'in_cicd') && (
+            <Alert severity="warning" sx={{ mt: 1 }}>
+              Some of these tests are used in automation. Deleting them may break your CI/CD pipeline.
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteAllOpen(false)} disabled={deleteAllPending}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDeleteAll}
+            color="error"
+            variant="contained"
+            disabled={deleteAllPending}
+            startIcon={<DeleteForeverIcon />}
+          >
+            {deleteAllPending ? 'Deleting…' : `Delete All ${cases.length}`}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Step 1 — Initial hard delete confirmation dialog */}
       <Dialog open={!!hardDeleteTarget} onClose={() => setHardDeleteTarget(null)} maxWidth="sm" fullWidth>

--- a/src/components/test-cases/TrashView.tsx
+++ b/src/components/test-cases/TrashView.tsx
@@ -124,8 +124,8 @@ export default function TrashView({ suiteId }: TrashViewProps) {
     }
   };
 
-  const handleDeleteAll = async () => {
-    const ids = cases.map((c) => c.id);
+  const handleBulkHardDelete = async () => {
+    const ids = Array.from(selected);
     if (ids.length === 0) return;
     setDeleteAllPending(true);
     try {
@@ -239,7 +239,7 @@ export default function TrashView({ suiteId }: TrashViewProps) {
               Restore {selected.size} selected
             </Button>
           )}
-          {cases.length > 0 && (
+          {selected.size > 0 && (
             <Button
               startIcon={<DeleteForeverIcon />}
               variant="outlined"
@@ -247,7 +247,7 @@ export default function TrashView({ suiteId }: TrashViewProps) {
               onClick={() => setDeleteAllOpen(true)}
               disabled={restoring.size > 0 || deleting.size > 0}
             >
-              Delete All
+              Delete {selected.size} selected
             </Button>
           )}
         </Box>
@@ -341,12 +341,12 @@ export default function TrashView({ suiteId }: TrashViewProps) {
         </DialogTitle>
         <DialogContent>
           <Typography variant="body2" gutterBottom>
-            Permanently delete all <strong>{cases.length} item{cases.length !== 1 ? 's' : ''}</strong> in the trash?
+            Permanently delete <strong>{Array.from(selected).length} selected item{Array.from(selected).length !== 1 ? 's' : ''}</strong>?
           </Typography>
           <Alert severity="error" sx={{ mt: 1 }}>
             This cannot be undone. All trashed test cases and their history will be permanently removed.
           </Alert>
-          {cases.some((c) => c.automation_status === 'in_cicd') && (
+          {cases.filter((c) => selected.has(c.id)).some((c) => c.automation_status === 'in_cicd') && (
             <Alert severity="warning" sx={{ mt: 1 }}>
               Some of these tests are used in automation. Deleting them may break your CI/CD pipeline.
             </Alert>
@@ -357,13 +357,13 @@ export default function TrashView({ suiteId }: TrashViewProps) {
             Cancel
           </Button>
           <Button
-            onClick={handleDeleteAll}
+            onClick={handleBulkHardDelete}
             color="error"
             variant="contained"
             disabled={deleteAllPending}
             startIcon={<DeleteForeverIcon />}
           >
-            {deleteAllPending ? 'Deleting…' : `Delete All ${cases.length}`}
+            {deleteAllPending ? 'Deleting…' : `Delete ${Array.from(selected).length} selected`}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Summary

Adds a **Delete selected** button to the /trash page that permanently hard-deletes the checked subset of trashed test cases.

## Changes

### API
- `POST /api/test-cases/bulk?action=hard_delete` — new bulk action that permanently deletes all supplied IDs that are already in the trash. Skips active (non-trashed) IDs. Editor+ required.

### UI (`TrashView.tsx`)
- **Delete selected** button appears in the toolbar when 1+ items are checked (mirrors the existing Restore X selected button)
- Shows count of selected items
- Confirmation dialog warns the action is irreversible; adds extra warning if any selected cases have `automation_status = in_cicd`

## No migration required
No schema changes — straight `DELETE` against existing table.