### PR TITLE
fix(trash): surface bulk hard-delete errors instead of silently failing

### DIFF
--- a/src/app/api/test-cases/bulk/route.ts
+++ b/src/app/api/test-cases/bulk/route.ts
@@ -164,11 +164,13 @@ async function handleBulkHardDelete(request: Request) {
   const toDelete = ids.filter((id: string) => existingMap.get(id)?.deleted_at);
 
   if (toDelete.length > 0) {
-    await supabase
+    const { error: deleteError } = await supabase
       .from('test_cases')
       .delete()
       .in('id', toDelete)
       .not('deleted_at', 'is', null); // guard: only touch trashed records
+
+    if (deleteError) return serverError(deleteError.message);
   }
 
   return NextResponse.json({

--- a/src/components/test-cases/TrashView.tsx
+++ b/src/components/test-cases/TrashView.tsx
@@ -134,13 +134,24 @@ export default function TrashView({ suiteId }: TrashViewProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids }),
       });
-      if (res.ok) {
-        const result = await res.json();
-        const deletedSet = new Set<string>(result.deleted ?? []);
-        setCases((prev) => prev.filter((c) => !deletedSet.has(c.id)));
-        setSelected(new Set());
+      const result = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(result?.error ?? `Delete failed (HTTP ${res.status})`);
         setDeleteAllOpen(false);
+        return;
       }
+      const deletedSet = new Set<string>(result.deleted ?? []);
+      if (deletedSet.size === 0) {
+        setError('Delete failed: no items were removed. Try refreshing and selecting again.');
+        setDeleteAllOpen(false);
+        return;
+      }
+      setCases((prev) => prev.filter((c) => !deletedSet.has(c.id)));
+      setSelected(new Set());
+      setDeleteAllOpen(false);
+    } catch (e) {
+      setError((e as Error).message ?? 'Unexpected error during delete');
+      setDeleteAllOpen(false);
     } finally {
       setDeleteAllPending(false);
     }


### PR DESCRIPTION
When the bulk permanent delete failed, the dialog closed and nothing happened — no feedback.\n\n- API: propagate Supabase delete errors via `serverError()` instead of swallowing them\n- UI: check `res.ok`, handle zero-deleted result explicitly, show error banner instead of silently resetting state\n\nAlso adds error state to surface any other unexpected failures (network, parse, etc.).