### PR TITLE
feat(mcp): Test Case CRUD epic — PRD + implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,8 @@ AGENT_TIMEOUT_MINUTES=10
 
 # Server-to-server key for Clutch agent monitor writes (generate with: openssl rand -hex 32)
 CLUTCH_API_KEY=
+
+# ─── MCP Agent Attribution ────────────────────────────────────────────────────
+# UUID of the dedicated Clutch Agent profile row in profiles — required for headless Clutch-key writes
+# Create via: INSERT INTO profiles (id, full_name, email, role) VALUES (gen_random_uuid(), 'Clutch Agent', 'clutch@agent.internal', 'viewer')
+MCP_AGENT_USER_ID=

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,14 @@
 {
   "mcpServers": {
+    "tcm": {
+      "command": "npx",
+      "args": ["--yes", "github:JoinFullStackDev/TCM#feat/mcp-e1-implementation", "--stdio"],
+      "env": {
+        "TCM_BASE_URL": "https://tcm-ochre.vercel.app",
+        "TCM_USER_TOKEN": "${TCM_USER_TOKEN}"
+      },
+      "_note": "Pin to a tag once feat/mcp-e1-implementation is tagged (e.g. github:JoinFullStackDev/TCM#v1.0.0). For headless Torque use: set CLUTCH_API_KEY instead of TCM_USER_TOKEN."
+    },
     "playwright": {
       "command": "npx",
       "args": [

--- a/docs/features/mcp-e1-test-case-crud.md
+++ b/docs/features/mcp-e1-test-case-crud.md
@@ -1,0 +1,437 @@
+# PRD — MCP Epic 1: Test Case CRUD
+
+**Status:** Draft
+**Epic:** Test Case CRUD (MCP tool surface)
+**Scope:** This epic only. Not the full MCP server, not other epics.
+**Author:** _TBD_
+**Last updated:** 2026-07-30
+
+---
+
+## 1. Problem Statement
+
+AI agents (Torque, triage-e2e, and general-purpose **Claude agents**) need to read and write test cases in TCM (TestForge Case Manager). Today they do this by issuing **raw Supabase REST calls** against the underlying Postgres schema. That approach is fragile and unsafe:
+
+- Agents must know internal table names, column names, enum values, and the `suite → project` join topology. A schema change breaks every agent.
+- Agents must resolve `display_id` (e.g. `APA-3`) to internal UUIDs themselves — but **there is no lookup endpoint for this today** (verified: all TCM REST routes key on the UUID `id`; `display_id` is only used for generation and search). Agents currently improvise this resolution.
+- Raw REST calls bypass TCM's validation layer (Zod schemas), its `display_id` generation RPC, its `in_cicd` display-id lock, and its soft-delete scoping conventions. An agent can write malformed or unsafe data directly.
+- Writes happen with **no human checkpoint**. An agent can create or overwrite test cases with no review.
+
+We want to replace raw REST access with a small set of **MCP tools** that expose test cases through a clean, schema-stable contract. Agents reference cases by `display_id` and never see UUIDs. Every write goes through a **dry-run → human approval → commit** flow: the dry-run **returns a summary to the calling agent**, and the agent presents it to a human wherever the human already is — **Slack** (Torque hands it to Clutch, which posts) or the **LLM chat itself** (Claude Code renders it inline). The MCP server itself never posts anywhere.
+
+## 2. Goals
+
+- **G1** — Give agents a stable, schema-agnostic tool contract for the full test-case lifecycle: resolve → list → read → create → update.
+- **G2** — Agents reference test cases exclusively by `display_id`. The MCP server resolves `display_id ↔ UUID` transparently. Agents never construct, pass, or receive internal UUIDs for a test case.
+- **G3** — No test case is created or mutated without an explicit human go-ahead. Every write tool supports `dry_run`, which **returns** a diff-style summary to the calling agent (instead of writing). The agent presents it for approval — Torque via Clutch→Slack, Claude Code inline in chat. The MCP server does not deliver the summary itself.
+- **G4** — Tool inputs are validated against TCM's real schema (enums, required fields, step shape) before any write, so agents cannot produce invalid data.
+- **G5** — Tools return exactly what agents need to act, no more. List/search returns a lightweight projection; `get` returns full detail including steps.
+
+### Non-Goals (this epic)
+
+Explicitly listed in **Section 4 — Out of Scope**.
+
+## 3. Success Metrics
+
+The four signals below are the axes of "did MCP help." **None is measurable without instrumentation** — see **§12 (Appendix C)** for how each is measured, the baseline required, and the `mcp_tool_calls` logging that makes them queryable. Metrics as stated here are the target; the appendix is the honest measurement plan.
+
+- **Reliability —** raw PostgREST traffic **against the test-case tables** from agent identities drops to ~zero. (Caveat: agents share the app's service-role key today, so this is only measurable if agents carry a distinguishable identity — see §12.)
+- **Safety —** every agent write is preceded by a **payload-matched dry-run in the same session**. With OQ-4 Option A the server does not enforce this, so measuring it is how we detect the accepted risk — requires correlation-id + payload logging (§12).
+- **Data quality —** **zero invalid rows land** in TCM (not "zero errors" — structured rejections are a _good_ signal the guard fires). Requires a **before baseline**: validate current `test_cases`/`test_steps` against the schema, then track new rows (§12).
+- **Schema resilience —** agent error-rate stays **flat across schema-change deploys** (before MCP, a column rename breaks agents silently). A counterfactual, so measured indirectly (§12); the win is one MCP maintainer absorbing a break instead of N agents.
+
+## 4. Out of Scope
+
+- **Building** the MCP server scaffolding itself (process bootstrap, tool registration, packaging the git-distributed `npx` package) — that construction is the MCP server foundation epic. This epic decides the architecture it must follow (§9.1, OQ-3: `npx` local stdio, thin client proxying TCM REST) and specifies the tool contracts.
+- Any tool beyond the six named below — no test-run, execution-result, bug-link, note, project, or suite-write tools. `search_suite` is read-only suite **lookup**, not suite management.
+- Deletion of test cases (soft or hard). No `delete_test_case` tool in v1.
+- Reordering / renumbering test cases (`reorder_test_cases` RPC is not exposed).
+- Bulk operations (bulk update, bulk delete, CSV import).
+- Any TCM/MCP-side posting to Slack. **The MCP server does not post to Slack or any chat** — it returns the dry-run summary to the agent, and the agent (Clutch for Torque, the chat for Claude Code) handles delivery and collects approval. TCM's existing run-notification Slack webhooks are unrelated to this flow. See **OQ-4** and the flow note in Section 6.
+- Version history / audit trail on updates, including the `change_reason` field (see **OQ-1**).
+  **In-scope prerequisite (not out of scope, flagged here):** because the data path proxies TCM REST (OQ-3), TCM must expose a **`display_id`-keyed REST surface** (get/create/update by `display_id` + suite lookup); its routes are UUID-keyed today. This REST work is a prerequisite for the tools and is tracked under OQ-3.
+
+## 5. Users & User Stories (agent-facing)
+
+The "users" of these tools are autonomous agents, not humans. A human enters the loop only to approve writes — in Slack (via Clutch) or in the LLM chat. The MCP tool returns the summary; the agent delivers it.
+
+- **US-1 (resolve a suite):** As **Torque**, before I can create or list cases, I need to turn a suite name or prefix like "APA" into the ID the case tools expect, so I call `search_suite("APA")` and get back a suite reference — without knowing TCM's suite table.
+- **US-2 (list cases):** As **triage-e2e**, I want to list the test cases in a suite (or matching a search term) with their automation status and priority, so I can find candidates for automation without loading full detail for every case.
+- **US-3 (read a case):** As a **Claude agent**, I want the full detail of `APA-3` — precondition, description, all steps with expected results — by its human-readable ID, so I can understand what the case verifies before editing it.
+- **US-4 (propose a new case, headless):** As **Torque** running with no human watching, I want to draft a new test case from a bug report, get the dry-run summary back from the tool, and post it to Slack **through Clutch** for a human to approve — so I never write an unreviewed case. After a human approves in the thread, I re-issue the call to commit it.
+- **US-5 (propose an edit, in chat):** As a **Claude agent (Claude Code)** working alongside a human, when a test's steps drift from the automation I want the dry-run summary back so I can show the diff **inline in the chat**, so the human confirms in the same conversation before I overwrite the live case — no Slack round-trip.
+- **US-6 (safety / no surprises):** As any agent, I want a `dry_run` write to **never** mutate TCM, and a non-dry-run write to require that a human has already approved, so I cannot accidentally commit unreviewed changes.
+
+## 6. The Dry-Run → Approval → Commit Flow
+
+All writes (`create_test_case`, `update_test_case`) follow the same two-pass contract.
+
+**Who delivers the summary:** The MCP server **does not post anywhere** — not to Slack, not to any chat. A dry-run **returns a formatted summary to the calling agent**, and the agent is responsible for presenting it to a human and getting approval:
+
+- **Torque (headless):** hands the summary to **Clutch**, which posts it to Slack; the human approves in Slack and Clutch relays the go-ahead back to the agent.
+- **Claude Code (human in the loop):** renders the summary **inline in the chat**; the human approves in the same conversation. No Slack involved.
+
+TCM's own Slack integration (`src/lib/slack/notify.ts`, `dispatch.ts` — run-completion webhooks) is **not** part of this flow. The MCP tool is delivery-agnostic: it emits the summary, nothing more.
+
+The two-pass contract:
+
+1. **Pass 1 — `dry_run: true` (required first).** The tool validates the input, resolves IDs, and computes a **diff-style summary** (for create: the full proposed case; for update: field-by-field before → after, plus a full steps before/after when `steps` is provided). It **returns that summary to the caller** and does **not** write to TCM. Delivering it to a human is the agent's job (Clutch→Slack for Torque, inline chat for Claude Code).
+2. **Human approval — out of band.** A human reviews the summary and tells the agent to proceed — via Clutch/Slack, or a message in the LLM chat. **v1 has no interactive button/callback**; approval is a human message the agent observes, not a callback into TCM (see **OQ-4**).
+3. **Pass 2 — `dry_run: false` (or omitted).** The agent re-issues the same call without dry-run. The tool re-validates, writes to TCM through the same code path as the UI/REST layer (`display_id` generated via the `generate_test_case_id` RPC on create; steps full-replaced on update), and returns the resulting `display_id` and canonical detail.
+
+**Design note (v1 constraint):** Because delivery and approval happen entirely on the agent's side, the MCP server **cannot itself verify** that a human approved before Pass 2. **v1 accepts this** — "no write without approval" is a **process/orchestration** convention enforced by the agent + the human, not a hard technical gate (decided: OQ-4 Option A). A stricter approval-token gate is a deferred option, sketched in §9.3.
+
+**Summary format:** The dry-run should return both a machine-readable diff and a human-readable rendering (markdown) so each agent can present it in its own channel — Clutch can wrap it for Slack, Claude Code can show the markdown directly. TCM does not format for any specific surface.
+
+## 7. Schema Facts (verified against code)
+
+These are the **code-verified** facts the tools must honor. Where they differ from the values stated in the epic brief, the code is authoritative and the delta is flagged. Sources: `supabase/migrations/00001_initial_schema.sql`, `src/lib/validations/test-case.ts`, `src/lib/validations/test-step.ts`, `src/types/database.ts`.
+
+| Field                       | Verified fact                                                                                                                                                                                                                          | Note vs. brief                                                                                                                                           |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `priority`                  | `text` with CHECK in **`low`, `medium`, `high`, `critical`**, nullable. Zod: `z.enum(['low','medium','high','critical']).nullable()`                                                                                                   | Brief lists `high/medium/low/null` only. Schema **also allows `critical`**. **v1 exposes the brief's set only; `critical` deferred to v2 (§9.1, OQ-5).** |
+| `automation_status`         | enum **`not_automated`, `scripted`, `in_cicd`, `out_of_sync`**, NOT NULL, default `not_automated`                                                                                                                                      | Matches brief.                                                                                                                                           |
+| `type`                      | enum `functional`, `performance`, NOT NULL, default `functional`                                                                                                                                                                       | Brief says `functional` is the only value in use. Schema **also allows `performance`**. v1 may hard-default to `functional` and not expose `type`.       |
+| `platform_tags`             | **`platform[]` — a constrained enum array of `desktop`, `tablet`, `mobile`**, NOT NULL, default `{}`                                                                                                                                   | ⚠️ Brief says "string array". It is **not** free-form; values are restricted to `desktop/tablet/mobile`. Tool schema must enforce this.                  |
+| `tags`                      | `text[]`, free strings (each ≤50 chars), NOT NULL, default `{}`                                                                                                                                                                        | Matches brief (free string array).                                                                                                                       |
+| `display_id`                | `text`, format `<suite.prefix>-<sequence_number>` (e.g. `APA-3`). Prefix lives on **`suites.prefix`**; numbering from `suites.next_sequence`. **Partial-unique on active rows only** (`WHERE deleted_at IS NULL`).                     | Resolution must scope to **active** (non-soft-deleted) rows.                                                                                             |
+| `project_id` on a case      | **Does not exist on `test_cases`.** Project is reached via `suite_id → suites.project_id`.                                                                                                                                             | `list_test_cases(project_id?)` must join through suites.                                                                                                 |
+| Steps                       | Table `test_steps`: `step_number` (int, ≥1, unique per case), `description` (required), `test_data?`, `expected_result?`, `is_automation_only` (bool, default false), `category?`. **Full-replace** semantics (delete all + reinsert). | Matches brief's "steps are full-replace".                                                                                                                |
+| `created_by` / `updated_by` | uuid, **NOT NULL** (`created_by`) FK → `profiles`.                                                                                                                                                                                     | Agent writes need an attributed profile id — see **OQ-2** / write-attribution note.                                                                      |
+| `in_cicd` lock              | When a case's `automation_status` is `in_cicd`, its `display_id` **cannot be changed** (enforced in `PATCH /api/test-cases/[id]`).                                                                                                     | `update_test_case` must respect this.                                                                                                                    |
+
+Fields the brief says **not to invent** and which are confirmed **absent** from the schema: `environment`, `risk_area`, `external_id`. Tools must not accept or return them.
+
+## 8. Tool Specifications
+
+General contract for all tools:
+
+- **Data path:** Per OQ-3, the MCP server is a thin client — each tool call proxies a **TCM REST endpoint** (it does not touch Supabase directly). References below to the `generate_test_case_id` RPC, the `in_cicd` lock, etc. describe what TCM does behind that REST call, not direct MCP→DB access.
+- **ID handling:** Agents pass `display_id` (cases) and suite references. The MCP server resolves to UUIDs internally (against the `display_id`-keyed REST surface) and never returns a test-case UUID to the agent.
+- **Validation:** Inputs validated against the enums/shapes in Section 7 before any read or write. Invalid input returns a structured error, not a silent coercion.
+- **Errors:** Return a structured error object `{ error: { code, message } }` — e.g. `NOT_FOUND` (unknown `display_id`/suite), `AMBIGUOUS` (search matches >1 suite), `VALIDATION` (bad enum/shape), `IN_CICD_LOCKED` (illegal display_id change). Mirror TCM's existing error style (`{ error, code }`). _(No `DRY_RUN_REQUIRED` code in v1 — with OQ-4 Option A the server does not enforce a prior dry-run; that code would only appear if the deferred token gate is added.)_
+
+---
+
+### 8.1 `search_suite`
+
+Resolve a suite name or prefix to a suite reference. Lightweight; agents call this before the case tools.
+
+**Input**
+
+| Param            | Type          | Req | Notes                                                                                |
+| ---------------- | ------------- | --- | ------------------------------------------------------------------------------------ |
+| `project_id`     | string (uuid) | yes | Scopes the search; prefix is only unique per project (`UNIQUE(project_id, prefix)`). |
+| `name_or_prefix` | string        | yes | Matches suite `name` or `prefix`, case-insensitive, prefix-or-substring.             |
+
+**Output** — array of matches (usually one):
+
+```json
+[
+  {
+    "suite_id": "uuid",
+    "name": "Account & Profile",
+    "prefix": "APA",
+    "project_id": "uuid"
+  }
+]
+```
+
+- 0 matches → `NOT_FOUND`. >1 match → return all so the agent (or human) can disambiguate; the agent must not guess.
+- `suite_id` **is** returned here (suites are not the entity we hide) — the case tools accept it. Only **test-case** UUIDs are hidden.
+
+---
+
+### 8.2 `list_test_cases`
+
+Filterable, lightweight list of cases.
+
+**Input**
+
+| Param        | Type          | Req | Notes                                                                                     |
+| ------------ | ------------- | --- | ----------------------------------------------------------------------------------------- |
+| `project_id` | string (uuid) | no  | Filters via `suite_id → suites.project_id` join.                                          |
+| `suite_id`   | string (uuid) | no  | Direct filter.                                                                            |
+| `search`     | string        | no  | Matches `display_id` or `title` (ilike), mirroring the existing list route.               |
+| `limit`      | int           | no  | Default **50**, max **200**. Values >200 clamp to 200 (and note the clamp in the result). |
+
+- At least one of `project_id` / `suite_id` / `search` should be provided; an unscoped full-table list is discouraged (still capped at `limit`).
+- Only **active** cases (`deleted_at IS NULL`).
+
+**Output** — array of lightweight rows:
+
+```json
+[
+  {
+    "display_id": "APA-3",
+    "title": "User can reset password",
+    "automation_status": "not_automated",
+    "priority": "high"
+  }
+]
+```
+
+Optionally a `total`/`has_more` indicator for pagination. No steps, no UUIDs.
+
+---
+
+### 8.3 `get_test_case`
+
+Full detail for a single case, including all steps.
+
+**Input**
+
+| Param        | Type   | Req | Notes                                                       |
+| ------------ | ------ | --- | ----------------------------------------------------------- |
+| `display_id` | string | yes | e.g. `APA-3`. MCP resolves to UUID against **active** rows. |
+
+**Output** — full case projection:
+
+```json
+{
+  "display_id": "APA-3",
+  "suite": { "suite_id": "uuid", "prefix": "APA", "name": "Account & Profile" },
+  "title": "User can reset password",
+  "precondition": "User has a registered account",
+  "description": "…",
+  "priority": "high",
+  "automation_status": "not_automated",
+  "type": "functional",
+  "platform_tags": ["desktop", "mobile"],
+  "tags": ["auth", "smoke"],
+  "steps": [
+    {
+      "step_number": 1,
+      "description": "Navigate to /forgot-password",
+      "test_data": null,
+      "expected_result": "Reset form shown",
+      "is_automation_only": false
+    }
+  ]
+}
+```
+
+- Unknown `display_id` → `NOT_FOUND`. Returns no internal UUID for the case itself.
+
+---
+
+### 8.4 `create_test_case`
+
+Create a case (with steps) via dry-run → approval → commit.
+
+**Input**
+
+| Param               | Type           | Req | Notes                                                                                                                                |
+| ------------------- | -------------- | --- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `suite_id`          | string (uuid)  | yes | From `search_suite`. Drives `display_id` prefix + numbering.                                                                         |
+| `title`             | string         | yes | 1–500 chars.                                                                                                                         |
+| `precondition`      | string \| null | no  | ≤5000.                                                                                                                               |
+| `description`       | string \| null | no  | ≤5000.                                                                                                                               |
+| `priority`          | enum \| null   | no  | `low`/`medium`/`high`, or null (`critical` deferred to v2, OQ-5).                                                                    |
+| `automation_status` | enum           | no  | Default `not_automated`.                                                                                                             |
+| `platform_tags`     | array<enum>    | no  | Subset of `desktop`/`tablet`/`mobile`. Default `[]`.                                                                                 |
+| `tags`              | array<string>  | no  | Free strings, each ≤50. Default `[]`.                                                                                                |
+| `steps`             | array<Step>    | yes | Ordered; each `{ description (req), test_data?, expected_result?, is_automation_only? }`. `step_number` assigned by order (1-based). |
+| `dry_run`           | boolean        | no  | `true` → return summary to the caller, no write. Omitted/`false` → commit.                                                           |
+
+**Behavior**
+
+- Dry-run: validate, resolve suite, compute and **return** the summary (**the assigned `display_id` is not known pre-write** — it comes from the `generate_test_case_id` RPC at insert time; the summary shows suite prefix + proposed content and notes the ID is assigned on commit). No write; the MCP server does not deliver the summary anywhere — the agent does.
+- Commit: insert case (display_id via `generate_test_case_id` RPC, position computed as in the existing POST route), insert steps. Attributed to the agent's write identity (**OQ-2**).
+
+**Output**
+
+- Dry-run: `{ dry_run: true, would_create: { …proposed case + steps… }, summary_markdown: "…" }` — the agent delivers this to a human (Clutch→Slack or inline chat).
+- Commit: the committed case in the `get_test_case` shape (with the real `display_id`).
+
+---
+
+### 8.5 `update_test_case`
+
+Partial update of an existing case; steps are **full-replace** when provided.
+
+**Input**
+
+| Param               | Type           | Req | Notes                                                                                   |
+| ------------------- | -------------- | --- | --------------------------------------------------------------------------------------- |
+| `display_id`        | string         | yes | Target case. MCP resolves to UUID.                                                      |
+| `title`             | string         | no  | Partial.                                                                                |
+| `precondition`      | string \| null | no  |                                                                                         |
+| `description`       | string \| null | no  |                                                                                         |
+| `priority`          | enum \| null   | no  |                                                                                         |
+| `automation_status` | enum           | no  |                                                                                         |
+| `platform_tags`     | array<enum>    | no  | `desktop`/`tablet`/`mobile`.                                                            |
+| `tags`              | array<string>  | no  |                                                                                         |
+| `steps`             | array<Step>    | no  | **If present, wipes and replaces ALL existing steps.** If omitted, steps are untouched. |
+| `dry_run`           | boolean        | no  | Same semantics as create.                                                               |
+
+**Behavior**
+
+- Only the fields supplied are changed. Omitted fields are untouched.
+- **Steps full-replace:** passing `steps` deletes all existing `test_steps` and reinserts the provided array (matching the existing `PUT /steps` route). The dry-run summary must show the **full before/after step list**, since a partial-looking call can wipe steps.
+- The tool does **not** accept a `display_id` change. (Renaming display_id is out of scope, and is `in_cicd`-locked in TCM anyway → `IN_CICD_LOCKED` if ever attempted.)
+- Commit attributes to the agent's write identity via `updated_by` (**OQ-2**).
+
+**Output**
+
+- Dry-run: `{ dry_run: true, diff: { field: { before, after }, … }, steps_before: [...], steps_after: [...], summary_markdown: "…" }` — the agent delivers this to a human (Clutch→Slack or inline chat).
+- Commit: updated case in the `get_test_case` shape.
+
+---
+
+## 9. Decisions & Open Questions
+
+### 9.1 Decisions (resolved)
+
+- **OQ-1 — `change_reason` / version history. → DECIDED: out of scope for v1.** We do **not** add a `change_reason` field, and version history is not part of this epic. The tools do not accept `change_reason`. (TCM has no field-level update audit trail today; adding one remains a separate, future decision, but nothing in this epic depends on it.)
+
+- **OQ-2 — MCP auth + write attribution. → DECIDED: two auth modes.** The MCP server authenticates one of two ways depending on the caller:
+  - **Clutch key (headless agents — Torque via Clutch/OpenClaw).** Reuse the existing **`X-Clutch-Key`** / `CLUTCH_API_KEY`, which already yields a service-role Supabase client via `withAgentAuth` (`src/lib/api/helpers.ts`). No new key needed for v1.
+  - **User auth token (interactive — Claude Code).** The MCP server acquires the **user's own Supabase session/JWT by logging in through the Playwright MCP** (the same browser-login pattern TCM already uses for Playwright auth, `scripts/save-playwright-auth.mjs` + `playwright/.auth/user.json`). Writes then run as that real user under normal RLS.
+  - **Write attribution follows the mode:** user-token writes attribute `created_by`/`updated_by` to that user's profile; Clutch-key writes are service-role and need a designated identity — **residual sub-question:** which profile do Clutch-key writes attribute to (a dedicated "agent"/service profile vs. per-agent profiles)? _(Also: the Clutch-key check is a plain, non-constant-time string compare — worth hardening.)_
+
+- **OQ-4 — Enforcing approval before commit. → DECIDED: Option A (process-only).** v1 does **not** build an approval-token gate. "No write without approval" is a **process/orchestration convention** enforced by the agent + the human (Torque via Clutch→Slack; Claude Code inline in chat) — the MCP server does not verify it. Known, accepted risk: a buggy or misbehaving agent could skip the dry-run and call with `dry_run: false` directly. The approval-token design (mint on dry-run → human acks → commit consumes a payload-matched, single-use token) is **deferred to a later version** if this convention proves insufficient; it is preserved in §9.3 for reference.
+
+- **OQ-5 — Enum surface (`critical`, `performance`). → DECIDED: defer to v2.** v1 exposes the narrow brief set only (`priority` ∈ `low`/`medium`/`high`/null; `type` fixed to `functional`, not exposed). Widening to the schema's `priority: critical` and `type: performance` is a **v2** consideration.
+
+- **OQ-3 — MCP server location, install & data path. → DECIDED.**
+  - **Transport & install: `npx`-launched local stdio server.** The MCP server ships as a package run as a local subprocess — the standard MCP install pattern and the same mechanism this repo already uses for the Playwright MCP in `.mcp.json`. Uniform across **both** install targets:
+    - **Local developer machine (Claude Code):** an `npx` entry in the developer's `.mcp.json` / user MCP settings, carrying the **user-token** auth path (OQ-2 — Playwright login → Supabase JWT).
+    - **Clutch / OpenClaw instance (headless agents):** the OpenClaw runtime launches the same `npx` server in each spawned Torque session (`POST /api/sessions/spawn`), carrying the **Clutch-key** auth path. (Depends on `OPENCLAW_INTEGRATION_ENABLED`, not live yet.)
+  - **Distribution: git URL — no npm publish.** The package is **not** published to npm (public or private). Hosts run it straight from the repo via a pinned git spec, e.g. `npx github:JoinFullStackDev/tcm-mcp#v1.0.0` (tag or commit — not a floating branch). Implications: (1) each host needs **git read access** to the repo — dev machines typically already have it; the **OpenClaw/Torque hosts need a git token** in their image/env. (2) Because npx clones and builds from source, the package needs a **`prepare` build step** (TS→JS on install) or a committed `dist/`. (3) Pin by tag/commit for reproducibility; bump the pin to roll out changes. The `.mcp.json` entry therefore references the git spec, not a bare `npx tcm-mcp` (which would imply the public registry).
+  - **Data path: proxy the TCM REST API (option 2).** The local server is a **thin client** — it does **not** touch Supabase directly. Every tool call maps to a TCM REST endpoint, so ID resolution, Zod validation, the `generate_test_case_id` RPC, the `in_cicd` lock, soft-delete scoping, and any audit logging stay centralized in TCM. Each host holds only a TCM base-URL + an auth credential (Clutch key or user JWT — OQ-2), never Supabase service creds. The server is thus effectively a standalone git-distributed package (not a Vercel function); where its _source_ lives (in-repo workspace vs. its own repo) is a minor code-org choice, not architectural — though the git-spec distribution assumes a repo the hosts can clone.
+  - **⚠️ Dependency this creates:** TCM's REST API is **UUID-keyed today** — there is no `display_id`→case surface. Proxying therefore requires either (a) **new `display_id`-keyed REST endpoints** on TCM (get/create/update by `display_id`, plus suite lookup), or (b) the MCP server resolves `display_id`→UUID via the existing `GET /api/test-cases?search=` list route and then calls the UUID-keyed endpoints. **Recommend (a)** for a clean contract. Either way, this REST work is a **prerequisite** for the epic and should be tracked as such.
+
+### 9.2 Open Questions (still open)
+
+- **OQ-2 residual — write attribution on the Clutch-key path.** The service-role (headless) path has no real user, but `created_by`/`updated_by` are NOT NULL. Which profile do those writes attribute to — a dedicated "agent"/service profile, or per-agent profiles? (The user-JWT path attributes to the real user automatically.)
+- **OQ-6 — Is `dry_run` a server-side REST concept?** Detailed in **§12.3**. Recommend making `dry_run` a `?dry_run=true` REST concept (validates + diffs + logs, no write) so the safety metric is measurable and validation runs on the dry-run too; not yet decided.
+
+### 9.3 Deferred designs (not in v1)
+
+- **OQ-4 Option B — approval token (kept for reference only; v1 uses Option A).** Make Pass 2 impossible without proof the dry-run happened and a human acked it. (1) **Mint on dry-run** — Pass 1 persists the exact proposed payload server-side under a short-lived, single-use `approval_token` in a **pending** state and returns it with the summary. (2) **Human acks** — approval flips the token to **approved** server-side via a callback (Clutch calls `POST /mcp/approvals/{token}/approve` on Slack approval; Claude Code surfaces an equivalent approve action). (3) **Commit consumes** — Pass 2 must send `approval_token`; the server writes only if it is approved, unexpired, unused, and its stored payload **matches** the commit payload (can't approve X then commit Y), then burns it. Cost: token storage + expiry, an approval-callback endpoint, and ack integration on both surfaces — which is why it is out of v1.
+
+## 10. Appendix — Key References
+
+| Concern                                                     | Path                                                      |
+| ----------------------------------------------------------- | --------------------------------------------------------- |
+| Test-case create/list route (display_id RPC, position calc) | `src/app/api/test-cases/route.ts`                         |
+| Test-case update route (`in_cicd` display_id lock)          | `src/app/api/test-cases/[testCaseId]/route.ts`            |
+| Steps full-replace route                                    | `src/app/api/test-cases/[testCaseId]/steps/route.ts`      |
+| Data-access repository (active-scope convention)            | `src/lib/db/test-case-repository.ts`                      |
+| Test-case / step Zod schemas (enum source of truth)         | `src/lib/validations/test-case.ts`, `test-step.ts`        |
+| Schema + `generate_test_case_id` RPC                        | `supabase/migrations/00001_initial_schema.sql`            |
+| `display_id` partial-unique (active rows)                   | `supabase/migrations/00038_partial_display_id_unique.sql` |
+| Clutch/agent auth helpers (`X-Clutch-Key`)                  | `src/lib/api/helpers.ts`                                  |
+| Slack Block Kit builder + webhook POST                      | `src/lib/slack/notify.ts`, `src/lib/slack/dispatch.ts`    |
+| Valid agent identities (incl. `torque`)                     | `src/lib/validations/agent-run.ts`                        |
+
+---
+
+## 11. Appendix B — Prerequisite REST surface (`display_id`-keyed)
+
+Because the MCP server proxies TCM REST (OQ-3, option 2), TCM must expose endpoints the tools can call **one-for-one**. TCM's routes are UUID-keyed today; this appendix specs the additions/extensions needed. This is **prerequisite build work for TCM**, tracked under OQ-3 — the MCP epic depends on it but does not itself build it.
+
+### Conventions (match existing TCM routes)
+
+- **Auth:** all endpoints below use **`withAgentAuth()`** (`src/lib/api/helpers.ts`) — accepts `X-Clutch-Key` (→ service-role, headless path) **or** `Authorization: Bearer <supabase-jwt>` (→ user RLS, interactive path). This is exactly OQ-2's two modes; no new auth code.
+- **Validation:** reuse the existing Zod schemas (`createTestCaseSchema`, `updateTestCaseSchema`, `stepSchema`) — but constrain the exposed enum surface to the v1 set (OQ-5): `priority` ∈ `low`/`medium`/`high`/null, `type` fixed to `functional`.
+- **Errors:** reuse TCM's shapes — `validationError` → `{ error: 'Validation failed', details }` (400); `notFound` → `{ error: '<entity> not found' }` (404); `conflict` (409); agent routes also carry a machine `code`. Add codes: `AMBIGUOUS_SUITE`, `IN_CICD_LOCKED`.
+- **Scope:** all reads/resolution are **active-only** (`deleted_at IS NULL`), via `TestCaseRepository`'s default scope. `display_id` resolves against active rows only (it is partial-unique on active rows).
+- **Fields:** snake_case, matching the DB/TS types.
+
+### Tool → endpoint map
+
+| MCP tool                    | REST endpoint                                              | New / extend                                                  |
+| --------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------- |
+| `search_suite`              | `GET /api/projects/{projectId}/suites?search=`             | **extend** (add `search` filter)                              |
+| `list_test_cases`           | `GET /api/test-cases?project_id=&suite_id=&search=&limit=` | **extend** (add `project_id`, `limit` clamp, lean projection) |
+| `get_test_case`             | `GET /api/test-cases/by-display-id/{displayId}`            | **new**                                                       |
+| `create_test_case` (commit) | `POST /api/test-cases` (accept inline `steps[]`)           | **extend** (atomic case + steps)                              |
+| `update_test_case` (commit) | `PATCH /api/test-cases/by-display-id/{displayId}`          | **new** (partial + steps full-replace)                        |
+
+**Dry-run needs no write endpoints** — it is pure reads: `get_test_case` (update before-state), `search_suite` (create prefix). The commit endpoints are the only writes.
+
+### E1 — Suite lookup (extend)
+
+`GET /api/projects/{projectId}/suites?search={name_or_prefix}`
+
+- Filters the existing suites list; case-insensitive match on `name` **or** `prefix`. Omitting `search` returns all (current behavior, unchanged).
+- **200:** `[{ "id": "uuid", "name": "Account & Profile", "prefix": "APA", "project_id": "uuid" }]`
+- The MCP maps this to `search_suite`; 0 matches → tool returns `NOT_FOUND`, >1 → tool returns `AMBIGUOUS` with all rows (endpoint itself just returns the array).
+
+### E2 — List cases (extend)
+
+`GET /api/test-cases?project_id={uuid}&suite_id={uuid}&search={str}&limit={n}`
+
+- Adds an optional **`project_id`** filter (join `suite:suites(project_id)` — cases have no direct `project_id`). `suite_id` and `search` (ilike on `display_id`/`title`) already exist.
+- **`limit`** default 50, **clamp to max 200**. Include `has_more`/`total` for paging.
+- Lean projection for this caller (either a `fields=lean` flag or MCP-side projection): `display_id`, `title`, `automation_status`, `priority`.
+- **200:** `{ "items": [{ "display_id": "APA-3", "title": "…", "automation_status": "not_automated", "priority": "high" }], "total": 12, "has_more": false }`
+
+### E3 — Get case by display_id (new)
+
+`GET /api/test-cases/by-display-id/{displayId}`
+
+- Resolves `display_id` → UUID against active rows, returns full detail **with steps** (reuse `findByIdWithRelations`).
+- **200:** the `get_test_case` shape (§8.3) — case fields + `suite` + ordered `steps[]`.
+- **404:** `{ error: 'Test case not found' }` (unknown/deleted `display_id`).
+
+### E4 — Create with inline steps (extend)
+
+`POST /api/test-cases`
+
+- Extend the existing create to accept an optional **`steps[]`** array and insert case **+ steps in one transaction** (today: case via `POST`, steps via a separate `PUT /steps`). Atomicity matters so a committed case is never stepless.
+- **Body:** `createTestCaseSchema` fields (`suite_id`, `title`, `precondition?`, `description?`, `priority?`, `automation_status?`, `platform_tags?`, `tags?`) **+ `steps[]`** (`stepSchema` items; `step_number` assigned by array order).
+- Server generates `display_id` via `generate_test_case_id` RPC and computes `position` (unchanged).
+- **201:** created case in the `get_test_case` shape (real `display_id` + steps).
+- **400:** `validationError`. Write RBAC via RLS (user path) or service-role (Clutch path).
+
+### E5 — Update by display_id, steps full-replace (new)
+
+`PATCH /api/test-cases/by-display-id/{displayId}`
+
+- Resolves `display_id` → UUID, applies a **partial** update, and — if `steps[]` is present — **wipes and replaces all steps** (same semantics as the existing `PUT /steps`), in one transaction. Omitting `steps` leaves steps untouched.
+- **Body:** `updateTestCaseSchema` fields (v1 subset) **+ optional `steps[]`**. Does **not** accept a `display_id` change; if the case is `in_cicd`, any display_id change is rejected → `409 IN_CICD_LOCKED` (mirrors the existing lock).
+- **200:** updated case in the `get_test_case` shape.
+- **404:** unknown/deleted `display_id`. **400:** `validationError`.
+
+### Notes / open sub-points
+
+- **Resolver reuse:** E3 and E5 share one internal `resolveDisplayId(displayId) → uuid | null` helper (active-scope). If TCM prefers not to add `by-display-id` paths, the fallback (OQ-3 option b) is: MCP calls E2 with `search={displayId}`, takes the exact `display_id` match, then hits the existing UUID routes — more round-trips, and it leaks the two-step resolution into the MCP. Dedicated endpoints (above) are recommended.
+- **Attribution:** on the Clutch-key (service-role) path, `created_by`/`updated_by` still need a value — see OQ-2's residual sub-question (which profile). The user-JWT path attributes to the real user automatically.
+
+---
+
+## 12. Appendix C — Success metrics: measurement & instrumentation
+
+The §3 metrics are only real if we can measure them. This appendix is the measurement plan. **Bottom line:** because the data path proxies TCM REST (OQ-3, option 2), **every tool call already crosses a TCM REST endpoint** — so we log **server-side at that boundary**, not in the MCP client. That is centralized, queryable, and **tamper-resistant** (a buggy/misbehaving agent cannot skip it — which matters precisely because OQ-4 Option A does not enforce the dry-run in code). This partially recovers the "no central observability" con listed under OQ-3, which really applied to the rejected direct-Supabase variant.
+
+### 12.1 Instrumentation — `mcp_tool_calls` (in-scope requirement)
+
+One row per proxied tool call, written at the TCM REST boundary. This single table makes all four signals queryable.
+
+| Column                             | Purpose                                                                                         |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `correlation_id`                   | Ties a dry-run to its commit (and both to an agent session).                                    |
+| `tool`                             | `search_suite` / `list_test_cases` / `get_test_case` / `create_test_case` / `update_test_case`. |
+| `dry_run`                          | boolean.                                                                                        |
+| `intent`                           | e.g. `dry-run-update`, `commit-create` — disambiguates a dry-run read from a plain read.        |
+| `actor_identity`                   | Clutch-key (which agent) vs. user JWT (which user).                                             |
+| `resolved_display_id` / `suite_id` | Target of the call.                                                                             |
+| `payload_hash`                     | Hash of the normalized write payload — lets us prove a commit **matches** its approved dry-run. |
+| `outcome` / `error_code`           | success / `VALIDATION` / `NOT_FOUND` / `IN_CICD_LOCKED` / …                                     |
+| `created_at`                       | timestamp.                                                                                      |
+
+**Two headers the MCP must stamp on proxied requests** so the boundary log is complete: `X-MCP-Correlation-Id` (groups dry-run ↔ commit ↔ session) and `X-MCP-Intent`. Without them, a dry-run for an update is just an ambiguous `GET`.
+
+### 12.2 How each signal is measured
+
+- **Reliability —** count PostgREST calls hitting `test_cases`/`test_steps` attributed to **agent identities**, over time; target ≈ 0 post-MCP. **Prerequisite:** agents must be distinguishable in Supabase logs — today they share `SUPABASE_SERVICE_ROLE_KEY` with the app backend, so filter by source (agent host IP / distinct key), not by the shared key alone. Scope to test-case tables only (v1 moves only test-case CRUD).
+- **Safety —** query `mcp_tool_calls` for commits (`dry_run=false`, write tools) with **no preceding `dry_run=true` row of matching `correlation_id` and `payload_hash`**. Target 0; any hit is the OQ-4 Option-A risk materializing (detected, not prevented).
+- **Data quality —** **baseline first:** run the current Zod schema over existing `test_cases`/`test_steps`, record the violation count. Post-MCP, track invalid rows _landed_ (should stay flat/zero) and, as a positive signal, the count of `outcome=VALIDATION` rejections (the guard doing its job). Framed as "zero invalid rows land," not "zero errors."
+- **Schema resilience —** track agent error-rate (from `mcp_tool_calls.outcome` and agent-run failures) in a window around migration deploys. Before MCP: expect spikes on schema changes. After: flat. Acknowledge it's a counterfactual — the benefit is a single MCP maintainer absorbing a break vs. N agents breaking silently; a TCM REST **response-shape** change can still break the MCP.
+
+### 12.3 Open question
+
+- **OQ-6 — Is `dry_run` a server-side REST concept?** Option A (current tool contract): the MCP computes the dry-run diff from reads, and `dry_run` never reaches TCM as a write intent. Option B: add `?dry_run=true` to the create/update REST endpoints (E4/E5) — TCM validates + computes the diff + logs it explicitly but does not write. Option B makes the safety metric trivially measurable, runs validation on the dry-run too, and is effectively the "mint" half of OQ-4 Option B already built (cheap upgrade path later). Trade-off: dry-run handling lands in the REST endpoints. **Recommend Option B** for measurability; not yet decided.

--- a/packages/tcm-mcp/package.json
+++ b/packages/tcm-mcp/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "tcm-mcp",
+  "version": "1.0.0",
+  "description": "MCP stdio server for TCM (Test Case CRUD — Epic 1)",
+  "main": "dist/index.js",
+  "bin": {
+    "tcm-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepare": "npm run build",
+    "dev": "ts-node src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "mcp",
+    "tcm",
+    "test-cases",
+    "fullstackrx"
+  ]
+}

--- a/packages/tcm-mcp/src/auth.ts
+++ b/packages/tcm-mcp/src/auth.ts
@@ -38,6 +38,14 @@ export function resolveAuthConfig(): AuthConfig {
   const userToken = process.env.TCM_USER_TOKEN;
 
   if (clutchKey) {
+    // Startup check: MCP_AGENT_USER_ID is required for headless create/update calls
+    // so that created_by / updated_by are not null (NOT NULL constraint on those columns).
+    if (!process.env.MCP_AGENT_USER_ID) {
+      console.warn(
+        '[tcm-mcp] WARNING: MCP_AGENT_USER_ID is not set — create/update calls will fail with NOT NULL constraint on created_by.\n' +
+        '  Set MCP_AGENT_USER_ID to the UUID of the Clutch Agent service profile row in the profiles table.',
+      );
+    }
     return {
       mode: 'clutch-key',
       baseUrl,

--- a/packages/tcm-mcp/src/auth.ts
+++ b/packages/tcm-mcp/src/auth.ts
@@ -1,0 +1,71 @@
+/**
+ * auth.ts — Two-mode auth for the TCM MCP server (PRD §9.1, OQ-2).
+ *
+ * Mode 1 — Clutch/headless path (Torque via OpenClaw):
+ *   CLUTCH_API_KEY env var → sends X-Clutch-Key on every proxied request.
+ *   Handled server-side by withAgentAuth() in TCM.
+ *
+ * Mode 2 — User/interactive path (Claude Code):
+ *   TCM_USER_TOKEN env var → sends Authorization: Bearer <token>.
+ *   Token is the user's Supabase JWT (from Playwright login or direct sign-in).
+ *
+ * TCM_BASE_URL is required in both modes.
+ */
+
+export type AuthMode = 'clutch-key' | 'user-token';
+
+export interface AuthConfig {
+  mode: AuthMode;
+  baseUrl: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * Resolve auth configuration from environment variables.
+ * Exits with a clear error if neither auth var is set, or if TCM_BASE_URL is missing.
+ */
+export function resolveAuthConfig(): AuthConfig {
+  const baseUrl = process.env.TCM_BASE_URL?.replace(/\/$/, '');
+  if (!baseUrl) {
+    console.error(
+      '[tcm-mcp] ERROR: TCM_BASE_URL is not set.\n' +
+      '  Set TCM_BASE_URL to your TCM instance (e.g. https://tcm-ochre.vercel.app).',
+    );
+    process.exit(1);
+  }
+
+  const clutchKey = process.env.CLUTCH_API_KEY;
+  const userToken = process.env.TCM_USER_TOKEN;
+
+  if (clutchKey) {
+    return {
+      mode: 'clutch-key',
+      baseUrl,
+      headers: {
+        'Content-Type': 'application/json',
+        // X-Clutch-Key: validated by withAgentAuth() in TCM (non-constant-time compare
+        // is a known minor weakness flagged in OQ-2; hardening is deferred to v2).
+        'X-Clutch-Key': clutchKey,
+      },
+    };
+  }
+
+  if (userToken) {
+    return {
+      mode: 'user-token',
+      baseUrl,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${userToken}`,
+      },
+    };
+  }
+
+  console.error(
+    '[tcm-mcp] ERROR: No auth credentials found.\n' +
+    '  Set one of:\n' +
+    '    CLUTCH_API_KEY — for headless agent use (Torque via Clutch/OpenClaw)\n' +
+    '    TCM_USER_TOKEN — for interactive use (Claude Code / user JWT)',
+  );
+  process.exit(1);
+}

--- a/packages/tcm-mcp/src/client.ts
+++ b/packages/tcm-mcp/src/client.ts
@@ -1,0 +1,86 @@
+/**
+ * client.ts — Thin REST client for TCM.
+ *
+ * The MCP server is a thin client: it does NOT touch Supabase directly.
+ * All reads/writes proxy TCM REST endpoints. ID resolution, Zod validation,
+ * the generate_test_case_id RPC, in_cicd locking, and soft-delete scoping
+ * all happen inside TCM. (PRD §8, OQ-3 option 2.)
+ */
+
+import type { AuthConfig } from './auth.js';
+import crypto from 'crypto';
+
+export interface RequestOptions {
+  method?: string;
+  body?: unknown;
+  /** MCP correlation ID for dry-run ↔ commit tracking (Appendix C). */
+  correlationId?: string;
+  /** MCP intent tag (e.g. 'dry-run-create', 'commit-update'). */
+  intent?: string;
+}
+
+export class TcmClient {
+  private readonly baseUrl: string;
+  private readonly defaultHeaders: Record<string, string>;
+
+  constructor(private readonly auth: AuthConfig) {
+    this.baseUrl = auth.baseUrl;
+    this.defaultHeaders = { ...auth.headers };
+  }
+
+  /**
+   * Make a request to TCM REST API.
+   * Throws on network failure; returns parsed JSON on success or HTTP error.
+   */
+  async request<T = unknown>(
+    path: string,
+    options: RequestOptions = {},
+  ): Promise<{ ok: boolean; status: number; data: T }> {
+    const { method = 'GET', body, correlationId, intent } = options;
+
+    const headers: Record<string, string> = { ...this.defaultHeaders };
+    if (correlationId) headers['X-MCP-Correlation-Id'] = correlationId;
+    if (intent) headers['X-MCP-Intent'] = intent;
+
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    let data: T;
+    try {
+      data = await res.json() as T;
+    } catch {
+      data = null as unknown as T;
+    }
+
+    return { ok: res.ok, status: res.status, data };
+  }
+
+  /** GET convenience */
+  async get<T>(path: string, opts?: Omit<RequestOptions, 'method' | 'body'>): Promise<{ ok: boolean; status: number; data: T }> {
+    return this.request<T>(path, { ...opts, method: 'GET' });
+  }
+
+  /** POST convenience */
+  async post<T>(path: string, body: unknown, opts?: Omit<RequestOptions, 'method' | 'body'>): Promise<{ ok: boolean; status: number; data: T }> {
+    return this.request<T>(path, { ...opts, method: 'POST', body });
+  }
+
+  /** PATCH convenience */
+  async patch<T>(path: string, body: unknown, opts?: Omit<RequestOptions, 'method' | 'body'>): Promise<{ ok: boolean; status: number; data: T }> {
+    return this.request<T>(path, { ...opts, method: 'PATCH', body });
+  }
+}
+
+/**
+ * Compute a SHA-256 hash of a normalized write payload for audit correlation.
+ * Used to verify a commit payload matches its approved dry-run (Appendix C).
+ */
+export function hashPayload(payload: unknown): string {
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(payload, Object.keys(payload as object).sort()))
+    .digest('hex');
+}

--- a/packages/tcm-mcp/src/index.ts
+++ b/packages/tcm-mcp/src/index.ts
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+/**
+ * TCM MCP Server — Epic 1: Test Case CRUD
+ *
+ * Stdio MCP server that gives AI agents (Torque, triage-e2e, Claude agents)
+ * a stable tool interface to read and write TCM test cases.
+ *
+ * Architecture: thin client — all reads/writes proxy TCM REST endpoints.
+ * Agents reference cases by display_id; UUIDs are never exposed.
+ *
+ * Tools:
+ *   search_suite     — resolve a suite name/prefix to a suite reference
+ *   list_test_cases  — filterable lightweight list
+ *   get_test_case    — full detail with steps
+ *   create_test_case — dry-run → approval → commit create
+ *   update_test_case — dry-run → approval → commit partial update (steps full-replace)
+ *
+ * Auth (OQ-2):
+ *   CLUTCH_API_KEY   → X-Clutch-Key (headless/Torque path)
+ *   TCM_USER_TOKEN   → Authorization: Bearer (interactive/Claude Code path)
+ *   TCM_BASE_URL     → required
+ *
+ * Distribution: git URL, no npm publish. Pin by tag/commit for reproducibility.
+ * See .mcp.json at repo root for Claude Code configuration.
+ *
+ * PRD: docs/features/mcp-e1-test-case-crud.md
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { resolveAuthConfig } from './auth.js';
+import { TcmClient } from './client.js';
+import { searchSuite } from './tools/search_suite.js';
+import { listTestCases } from './tools/list_test_cases.js';
+import { getTestCase } from './tools/get_test_case.js';
+import { createTestCase } from './tools/create_test_case.js';
+import { updateTestCase } from './tools/update_test_case.js';
+
+// ─── Tool definitions ─────────────────────────────────────────────────────────
+
+const TOOLS: Tool[] = [
+  {
+    name: 'search_suite',
+    description:
+      'Resolve a suite name or prefix to a suite reference. ' +
+      'Call this before create_test_case or list_test_cases to get the suite_id. ' +
+      'Returns all matches so the caller can disambiguate if >1.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project_id: {
+          type: 'string',
+          description: 'Project UUID. Scopes the search (prefix is only unique per project).',
+        },
+        name_or_prefix: {
+          type: 'string',
+          description: 'Suite name or prefix to search (case-insensitive, substring match).',
+        },
+      },
+      required: ['project_id', 'name_or_prefix'],
+    },
+  },
+  {
+    name: 'list_test_cases',
+    description:
+      'List test cases with lightweight projection (display_id, title, automation_status, priority). ' +
+      'Filterable by project, suite, or search term. Default limit 50, max 200.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        project_id: { type: 'string', description: 'Filter by project UUID (joins through suite).' },
+        suite_id: { type: 'string', description: 'Filter by suite UUID.' },
+        search: { type: 'string', description: 'ilike match on display_id or title.' },
+        limit: { type: 'number', description: 'Max results (default 50, max 200).' },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'get_test_case',
+    description:
+      'Get full detail of a test case by display_id (e.g. "APA-3"), including all steps. ' +
+      'Use this before update_test_case to review the current state.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        display_id: {
+          type: 'string',
+          description: 'Human-readable test case ID, e.g. "APA-3".',
+        },
+      },
+      required: ['display_id'],
+    },
+  },
+  {
+    name: 'create_test_case',
+    description:
+      'Create a test case with steps. ' +
+      'REQUIRED: call with dry_run: true first. Review the summary with a human. ' +
+      'Only call with dry_run: false (or omit dry_run) after explicit human approval. ' +
+      'Steps are required. display_id is assigned by TCM on commit.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        suite_id: { type: 'string', description: 'Suite UUID (from search_suite).' },
+        title: { type: 'string', description: 'Test case title (1–500 chars).' },
+        precondition: { type: 'string', description: 'Precondition text (optional).', nullable: true },
+        description: { type: 'string', description: 'Description text (optional).', nullable: true },
+        priority: {
+          type: 'string',
+          enum: ['low', 'medium', 'high'],
+          description: 'Priority (v1: low/medium/high only; critical deferred to v2).',
+          nullable: true,
+        },
+        automation_status: {
+          type: 'string',
+          enum: ['not_automated', 'scripted', 'in_cicd', 'out_of_sync'],
+          description: 'Default: not_automated.',
+        },
+        platform_tags: {
+          type: 'array',
+          items: { type: 'string', enum: ['desktop', 'tablet', 'mobile'] },
+          description: 'Platform tags (constrained enum: desktop/tablet/mobile only).',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Free-form tags (each ≤50 chars).',
+        },
+        steps: {
+          type: 'array',
+          description: 'Test steps (required; step_number assigned by order, 1-based).',
+          items: {
+            type: 'object',
+            properties: {
+              description: { type: 'string', description: 'Step description (required).' },
+              test_data: { type: 'string', description: 'Test data.', nullable: true },
+              expected_result: { type: 'string', description: 'Expected result.', nullable: true },
+              is_automation_only: { type: 'boolean', description: 'Automation-only step.' },
+            },
+            required: ['description'],
+          },
+        },
+        dry_run: {
+          type: 'boolean',
+          description:
+            'true → validate + return summary to caller, no write. ' +
+            'false/omit → commit (only after human approval of a dry-run).',
+        },
+      },
+      required: ['suite_id', 'title', 'steps'],
+    },
+  },
+  {
+    name: 'update_test_case',
+    description:
+      'Partially update an existing test case by display_id. ' +
+      'If steps is provided, ALL existing steps are wiped and replaced (full-replace — not partial). ' +
+      'REQUIRED: call with dry_run: true first. The dry-run shows the full before/after diff including steps. ' +
+      'Only call with dry_run: false after explicit human approval.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        display_id: { type: 'string', description: 'Target test case display_id, e.g. "APA-3".' },
+        title: { type: 'string', description: 'New title (optional).' },
+        precondition: { type: 'string', description: 'New precondition (optional).', nullable: true },
+        description: { type: 'string', description: 'New description (optional).', nullable: true },
+        priority: {
+          type: 'string',
+          enum: ['low', 'medium', 'high'],
+          description: 'New priority (optional).',
+          nullable: true,
+        },
+        automation_status: {
+          type: 'string',
+          enum: ['not_automated', 'scripted', 'in_cicd', 'out_of_sync'],
+          description: 'New automation status (optional).',
+        },
+        platform_tags: {
+          type: 'array',
+          items: { type: 'string', enum: ['desktop', 'tablet', 'mobile'] },
+          description: 'New platform tags (optional, replaces all).',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'New tags (optional, replaces all).',
+        },
+        steps: {
+          type: 'array',
+          description:
+            'If provided: FULL REPLACE of ALL steps. Omit to leave steps unchanged.',
+          items: {
+            type: 'object',
+            properties: {
+              description: { type: 'string' },
+              test_data: { type: 'string', nullable: true },
+              expected_result: { type: 'string', nullable: true },
+              is_automation_only: { type: 'boolean' },
+            },
+            required: ['description'],
+          },
+        },
+        dry_run: {
+          type: 'boolean',
+          description:
+            'true → compute diff + return to caller, no write. ' +
+            'false/omit → commit (only after human approval).',
+        },
+      },
+      required: ['display_id'],
+    },
+  },
+];
+
+// ─── Server bootstrap ─────────────────────────────────────────────────────────
+
+async function main() {
+  const auth = resolveAuthConfig();
+  const tcmClient = new TcmClient(auth);
+
+  console.error(`[tcm-mcp] Starting. Mode: ${auth.mode}. Base URL: ${auth.baseUrl}`);
+
+  const server = new Server(
+    { name: 'tcm-mcp', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  // List tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: TOOLS,
+  }));
+
+  // Handle tool calls
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    const input = args as Record<string, unknown>;
+
+    // Extract correlation ID from meta if provided by the calling agent
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const meta = (request.params as any)._meta as Record<string, unknown> | undefined;
+    const correlationId = meta?.correlationId as string | undefined;
+
+    let result: unknown;
+
+    switch (name) {
+      case 'search_suite':
+        result = await searchSuite(tcmClient, input as Parameters<typeof searchSuite>[1]);
+        break;
+
+      case 'list_test_cases':
+        result = await listTestCases(tcmClient, input as Parameters<typeof listTestCases>[1]);
+        break;
+
+      case 'get_test_case':
+        result = await getTestCase(tcmClient, input as Parameters<typeof getTestCase>[1]);
+        break;
+
+      case 'create_test_case':
+        result = await createTestCase(
+          tcmClient,
+          input as Parameters<typeof createTestCase>[1],
+          correlationId,
+        );
+        break;
+
+      case 'update_test_case':
+        result = await updateTestCase(
+          tcmClient,
+          input as Parameters<typeof updateTestCase>[1],
+          correlationId,
+        );
+        break;
+
+      default:
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ error: { code: 'NOT_FOUND', message: `Unknown tool: ${name}` } }),
+            },
+          ],
+          isError: true,
+        };
+    }
+
+    const isError =
+      result !== null &&
+      typeof result === 'object' &&
+      'error' in (result as object) &&
+      (result as { error: unknown }).error !== undefined;
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+      isError,
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  console.error('[tcm-mcp] Ready. Listening on stdio.');
+}
+
+main().catch((err) => {
+  console.error('[tcm-mcp] Fatal error:', err);
+  process.exit(1);
+});

--- a/packages/tcm-mcp/src/tools/create_test_case.ts
+++ b/packages/tcm-mcp/src/tools/create_test_case.ts
@@ -1,0 +1,123 @@
+/**
+ * create_test_case — Create a test case (with steps) via dry-run → approval → commit.
+ *
+ * Proxies: POST /api/test-cases (with dry_run support via E4 extension)
+ * PRD §8.4, OQ-6 Option B
+ */
+
+import { z } from 'zod';
+import type { TcmClient } from '../client.js';
+import type { TestCaseDetail, CreateDryRunResult, McpError } from '../types.js';
+import { hashPayload } from '../client.js';
+
+const priorityEnum = z.enum(['low', 'medium', 'high']);
+const automationStatusEnum = z.enum(['not_automated', 'scripted', 'in_cicd', 'out_of_sync']);
+const platformTagEnum = z.enum(['desktop', 'tablet', 'mobile']);
+
+const stepInputSchema = z.object({
+  description: z.string().min(1, 'Step description is required').max(5000),
+  test_data: z.string().max(5000).nullable().optional(),
+  expected_result: z.string().max(5000).nullable().optional(),
+  is_automation_only: z.boolean().optional().default(false),
+});
+
+export const createTestCaseInputSchema = z.object({
+  suite_id: z.string().uuid('suite_id must be a valid UUID'),
+  title: z.string().min(1, 'Title is required').max(500),
+  precondition: z.string().max(5000).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  /** v1: low/medium/high only. critical is deferred to v2 (OQ-5). */
+  priority: priorityEnum.nullable().optional(),
+  automation_status: automationStatusEnum.optional().default('not_automated'),
+  /** Constrained enum — desktop/tablet/mobile only, not free-form (PRD §7). */
+  platform_tags: z.array(platformTagEnum).optional().default([]),
+  tags: z.array(z.string().max(50)).optional().default([]),
+  steps: z.array(stepInputSchema).min(0),
+  /**
+   * dry_run: true → validate + return summary, no write.
+   * false/omitted → commit.
+   * (OQ-6 Option B: dry_run is passed to TCM REST endpoint for server-side logging.)
+   */
+  dry_run: z.boolean().optional().default(false),
+});
+
+export type CreateTestCaseInput = z.infer<typeof createTestCaseInputSchema>;
+
+export async function createTestCase(
+  client: TcmClient,
+  input: CreateTestCaseInput,
+  correlationId?: string,
+): Promise<TestCaseDetail | CreateDryRunResult | McpError> {
+  const parsed = createTestCaseInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      error: {
+        code: 'VALIDATION',
+        message: `Invalid input: ${JSON.stringify(parsed.error.flatten())}`,
+      },
+    };
+  }
+
+  const data = parsed.data;
+  const isDryRun = data.dry_run === true;
+
+  // Compute payload hash for audit correlation
+  const payloadHash = hashPayload({
+    suite_id: data.suite_id,
+    title: data.title,
+    precondition: data.precondition,
+    description: data.description,
+    priority: data.priority,
+    automation_status: data.automation_status,
+    platform_tags: data.platform_tags,
+    tags: data.tags,
+    steps: data.steps,
+  });
+
+  const body = {
+    suite_id: data.suite_id,
+    title: data.title,
+    precondition: data.precondition ?? null,
+    description: data.description ?? null,
+    priority: data.priority ?? null,
+    automation_status: data.automation_status,
+    platform_tags: data.platform_tags,
+    tags: data.tags,
+    steps: data.steps.map((s, i) => ({ ...s, step_number: i + 1 })),
+    dry_run: isDryRun,
+  };
+
+  const res = await client.post<TestCaseDetail | CreateDryRunResult | { error: string }>(
+    '/api/test-cases',
+    body,
+    {
+      correlationId,
+      intent: isDryRun ? 'dry-run-create' : 'commit-create',
+    },
+  );
+
+  if (res.status === 400) {
+    return {
+      error: {
+        code: 'VALIDATION',
+        message: `Validation failed: ${JSON.stringify((res.data as { error?: string; details?: unknown })?.details ?? res.data)}`,
+      },
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      error: {
+        code: 'SERVER_ERROR',
+        message: `TCM returned ${res.status}: ${JSON.stringify(res.data)}`,
+      },
+    };
+  }
+
+  // Return dry-run result or committed case
+  const result = res.data as TestCaseDetail | CreateDryRunResult;
+
+  // Attach payload hash to result for audit reference (not in PRD shape — extra)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { ...(result as any), _payload_hash: payloadHash } as unknown as typeof result;
+}

--- a/packages/tcm-mcp/src/tools/get_test_case.ts
+++ b/packages/tcm-mcp/src/tools/get_test_case.ts
@@ -1,0 +1,56 @@
+/**
+ * get_test_case — Full detail for a single test case, including all steps.
+ *
+ * Proxies: GET /api/test-cases/by-display-id/{displayId}
+ * PRD §8.3
+ */
+
+import { z } from 'zod';
+import type { TcmClient } from '../client.js';
+import type { TestCaseDetail, McpError } from '../types.js';
+
+export const getTestCaseInputSchema = z.object({
+  display_id: z.string().min(1, 'display_id is required'),
+});
+
+export type GetTestCaseInput = z.infer<typeof getTestCaseInputSchema>;
+
+export async function getTestCase(
+  client: TcmClient,
+  input: GetTestCaseInput,
+): Promise<TestCaseDetail | McpError> {
+  const parsed = getTestCaseInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      error: {
+        code: 'VALIDATION',
+        message: `Invalid input: ${JSON.stringify(parsed.error.flatten())}`,
+      },
+    };
+  }
+
+  const { display_id } = parsed.data;
+  const path = `/api/test-cases/by-display-id/${encodeURIComponent(display_id)}`;
+
+  const res = await client.get<TestCaseDetail | { error: string }>(path);
+
+  if (res.status === 404) {
+    return {
+      error: {
+        code: 'NOT_FOUND',
+        message: `Test case "${display_id}" not found or deleted`,
+      },
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      error: {
+        code: 'SERVER_ERROR',
+        message: `TCM returned ${res.status}`,
+      },
+    };
+  }
+
+  return res.data as TestCaseDetail;
+}

--- a/packages/tcm-mcp/src/tools/list_test_cases.ts
+++ b/packages/tcm-mcp/src/tools/list_test_cases.ts
@@ -1,0 +1,87 @@
+/**
+ * list_test_cases — Filterable, lightweight list of test cases.
+ *
+ * Proxies: GET /api/test-cases?project_id=&suite_id=&search=&limit=&fields=lean
+ * PRD §8.2
+ */
+
+import { z } from 'zod';
+import type { TcmClient } from '../client.js';
+import type { ListTestCasesResult, McpError } from '../types.js';
+
+const LIST_LIMIT_MAX = 200;
+const LIST_LIMIT_DEFAULT = 50;
+
+export const listTestCasesInputSchema = z.object({
+  project_id: z.string().uuid().optional(),
+  suite_id: z.string().uuid().optional(),
+  search: z.string().optional(),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(LIST_LIMIT_MAX)
+    .optional()
+    .default(LIST_LIMIT_DEFAULT),
+});
+
+export type ListTestCasesInput = z.infer<typeof listTestCasesInputSchema>;
+
+export async function listTestCases(
+  client: TcmClient,
+  input: ListTestCasesInput,
+): Promise<ListTestCasesResult | McpError> {
+  const parsed = listTestCasesInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      error: {
+        code: 'VALIDATION',
+        message: `Invalid input: ${JSON.stringify(parsed.error.flatten())}`,
+      },
+    };
+  }
+
+  const { project_id, suite_id, search, limit } = parsed.data;
+  const clampedLimit = Math.min(limit ?? LIST_LIMIT_DEFAULT, LIST_LIMIT_MAX);
+
+  const params = new URLSearchParams({ fields: 'lean', limit: String(clampedLimit) });
+  if (project_id) params.set('project_id', project_id);
+  if (suite_id) params.set('suite_id', suite_id);
+  if (search) params.set('search', search);
+
+  const res = await client.get<ListTestCasesResult | unknown[]>(`/api/test-cases?${params}`);
+
+  if (!res.ok) {
+    return {
+      error: {
+        code: 'SERVER_ERROR',
+        message: `TCM returned ${res.status}`,
+      },
+    };
+  }
+
+  // TCM returns { items, total, has_more } when fields=lean
+  if (res.data && typeof res.data === 'object' && 'items' in (res.data as object)) {
+    const result = res.data as ListTestCasesResult;
+    const notedClamp = (limit ?? LIST_LIMIT_DEFAULT) > LIST_LIMIT_MAX;
+    return {
+      items: result.items ?? [],
+      total: result.total ?? (result.items ?? []).length,
+      has_more: result.has_more || notedClamp,
+    };
+  }
+
+  // Fallback: raw array (older TCM versions without lean support)
+  const items = Array.isArray(res.data) ? res.data : [];
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    items: items.map((tc: any) => ({
+      display_id: tc.display_id,
+      title: tc.title,
+      automation_status: tc.automation_status,
+      priority: tc.priority,
+    })),
+    total: items.length,
+    has_more: false,
+  };
+}

--- a/packages/tcm-mcp/src/tools/search_suite.ts
+++ b/packages/tcm-mcp/src/tools/search_suite.ts
@@ -1,0 +1,65 @@
+/**
+ * search_suite — Resolve a suite name or prefix to a suite reference.
+ *
+ * Proxies: GET /api/projects/{projectId}/suites?search={name_or_prefix}
+ * PRD §8.1
+ */
+
+import { z } from 'zod';
+import type { TcmClient } from '../client.js';
+import type { SuiteRef, McpError } from '../types.js';
+
+export const searchSuiteInputSchema = z.object({
+  project_id: z.string().uuid('project_id must be a valid UUID'),
+  name_or_prefix: z.string().min(1, 'name_or_prefix is required'),
+});
+
+export type SearchSuiteInput = z.infer<typeof searchSuiteInputSchema>;
+
+export async function searchSuite(
+  client: TcmClient,
+  input: SearchSuiteInput,
+): Promise<SuiteRef[] | McpError> {
+  const parsed = searchSuiteInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      error: {
+        code: 'VALIDATION',
+        message: `Invalid input: ${JSON.stringify(parsed.error.flatten())}`,
+      },
+    };
+  }
+
+  const { project_id, name_or_prefix } = parsed.data;
+  const path = `/api/projects/${project_id}/suites?search=${encodeURIComponent(name_or_prefix)}`;
+
+  const res = await client.get<SuiteRef[]>(path);
+
+  if (!res.ok) {
+    return {
+      error: {
+        code: 'SERVER_ERROR',
+        message: `TCM returned ${res.status}`,
+      },
+    };
+  }
+
+  const suites = res.data ?? [];
+
+  if (suites.length === 0) {
+    return {
+      error: {
+        code: 'NOT_FOUND',
+        message: `No suite found matching "${name_or_prefix}" in project ${project_id}`,
+      },
+    };
+  }
+
+  // Map TCM response to SuiteRef shape (TCM returns id, not suite_id)
+  return suites.map((s: SuiteRef & { id?: string }) => ({
+    suite_id: (s as { id?: string; suite_id?: string }).id ?? s.suite_id,
+    name: s.name,
+    prefix: s.prefix,
+    project_id: s.project_id,
+  })) as SuiteRef[];
+}

--- a/packages/tcm-mcp/src/tools/update_test_case.ts
+++ b/packages/tcm-mcp/src/tools/update_test_case.ts
@@ -1,0 +1,127 @@
+/**
+ * update_test_case — Partial update of an existing test case; steps are full-replace when provided.
+ *
+ * Proxies: PATCH /api/test-cases/by-display-id/{displayId} (E5)
+ * PRD §8.5, OQ-6 Option B
+ */
+
+import { z } from 'zod';
+import type { TcmClient } from '../client.js';
+import type { TestCaseDetail, UpdateDryRunResult, McpError } from '../types.js';
+import { hashPayload } from '../client.js';
+
+const priorityEnum = z.enum(['low', 'medium', 'high']);
+const automationStatusEnum = z.enum(['not_automated', 'scripted', 'in_cicd', 'out_of_sync']);
+const platformTagEnum = z.enum(['desktop', 'tablet', 'mobile']);
+
+const stepInputSchema = z.object({
+  description: z.string().min(1, 'Step description is required').max(5000),
+  test_data: z.string().max(5000).nullable().optional(),
+  expected_result: z.string().max(5000).nullable().optional(),
+  is_automation_only: z.boolean().optional().default(false),
+});
+
+export const updateTestCaseInputSchema = z.object({
+  display_id: z.string().min(1, 'display_id is required'),
+  title: z.string().min(1).max(500).optional(),
+  precondition: z.string().max(5000).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  /** v1: low/medium/high only. critical deferred to v2 (OQ-5). */
+  priority: priorityEnum.nullable().optional(),
+  automation_status: automationStatusEnum.optional(),
+  platform_tags: z.array(platformTagEnum).optional(),
+  tags: z.array(z.string().max(50)).optional(),
+  /**
+   * If provided, wipes ALL existing steps and inserts these (full-replace).
+   * The dry-run summary shows the full before/after step list.
+   * If omitted, steps are untouched.
+   */
+  steps: z.array(stepInputSchema).optional(),
+  /**
+   * dry_run: true → validate, resolve IDs, compute and return diff. No write.
+   * false/omitted → commit.
+   */
+  dry_run: z.boolean().optional().default(false),
+});
+
+export type UpdateTestCaseInput = z.infer<typeof updateTestCaseInputSchema>;
+
+export async function updateTestCase(
+  client: TcmClient,
+  input: UpdateTestCaseInput,
+  correlationId?: string,
+): Promise<TestCaseDetail | UpdateDryRunResult | McpError> {
+  const parsed = updateTestCaseInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      error: {
+        code: 'VALIDATION',
+        message: `Invalid input: ${JSON.stringify(parsed.error.flatten())}`,
+      },
+    };
+  }
+
+  const { display_id, dry_run, ...updates } = parsed.data;
+  const isDryRun = dry_run === true;
+
+  // Compute payload hash for audit correlation
+  const payloadHash = hashPayload({ display_id, ...updates });
+
+  const body = {
+    ...updates,
+    dry_run: isDryRun,
+  };
+
+  const path = `/api/test-cases/by-display-id/${encodeURIComponent(display_id)}${isDryRun ? '?dry_run=true' : ''}`;
+
+  const res = await client.patch<TestCaseDetail | UpdateDryRunResult | { error: string; code?: string }>(
+    path,
+    body,
+    {
+      correlationId,
+      intent: isDryRun ? 'dry-run-update' : 'commit-update',
+    },
+  );
+
+  if (res.status === 404) {
+    return {
+      error: {
+        code: 'NOT_FOUND',
+        message: `Test case "${display_id}" not found or deleted`,
+      },
+    };
+  }
+
+  if (res.status === 409) {
+    const errData = res.data as { error?: string; code?: string };
+    const code = errData?.code === 'IN_CICD_LOCKED' ? 'IN_CICD_LOCKED' as const : 'SERVER_ERROR' as const;
+    return {
+      error: {
+        code,
+        message: errData?.error ?? 'Conflict: test case may be in_cicd locked',
+      },
+    };
+  }
+
+  if (res.status === 400) {
+    return {
+      error: {
+        code: 'VALIDATION',
+        message: `Validation failed: ${JSON.stringify((res.data as { details?: unknown })?.details ?? res.data)}`,
+      },
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      error: {
+        code: 'SERVER_ERROR',
+        message: `TCM returned ${res.status}: ${JSON.stringify(res.data)}`,
+      },
+    };
+  }
+
+  const result = res.data as TestCaseDetail | UpdateDryRunResult;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { ...(result as any), _payload_hash: payloadHash } as unknown as typeof result;
+}

--- a/packages/tcm-mcp/src/types.ts
+++ b/packages/tcm-mcp/src/types.ts
@@ -1,0 +1,144 @@
+/**
+ * Shared input/output types for the TCM MCP server.
+ * All shapes match PRD §8 exactly.
+ * Internal UUIDs are never exposed for test cases (only suite_id is returned).
+ */
+
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+export type Priority = 'low' | 'medium' | 'high';
+export type AutomationStatus = 'not_automated' | 'scripted' | 'in_cicd' | 'out_of_sync';
+export type PlatformTag = 'desktop' | 'tablet' | 'mobile';
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+export interface SuiteRef {
+  suite_id: string;
+  name: string;
+  prefix: string;
+  project_id: string;
+}
+
+// ─── Steps ────────────────────────────────────────────────────────────────────
+
+export interface StepInput {
+  description: string;
+  test_data?: string | null;
+  expected_result?: string | null;
+  is_automation_only?: boolean;
+}
+
+export interface Step extends StepInput {
+  step_number: number;
+  is_automation_only: boolean;
+}
+
+// ─── Tool Inputs ──────────────────────────────────────────────────────────────
+
+export interface SearchSuiteInput {
+  project_id: string;
+  name_or_prefix: string;
+}
+
+export interface ListTestCasesInput {
+  project_id?: string;
+  suite_id?: string;
+  search?: string;
+  /** Default 50, max 200. Values >200 are clamped to 200. */
+  limit?: number;
+}
+
+export interface GetTestCaseInput {
+  display_id: string;
+}
+
+export interface CreateTestCaseInput {
+  suite_id: string;
+  title: string;
+  precondition?: string | null;
+  description?: string | null;
+  priority?: Priority | null;
+  automation_status?: AutomationStatus;
+  platform_tags?: PlatformTag[];
+  tags?: string[];
+  steps: StepInput[];
+  dry_run?: boolean;
+}
+
+export interface UpdateTestCaseInput {
+  display_id: string;
+  title?: string;
+  precondition?: string | null;
+  description?: string | null;
+  priority?: Priority | null;
+  automation_status?: AutomationStatus;
+  platform_tags?: PlatformTag[];
+  tags?: string[];
+  /** If provided, wipes and replaces ALL existing steps (full-replace). */
+  steps?: StepInput[];
+  dry_run?: boolean;
+}
+
+// ─── Tool Outputs ─────────────────────────────────────────────────────────────
+
+/** Lightweight list item — no steps, no UUIDs. */
+export interface TestCaseListItem {
+  display_id: string;
+  title: string;
+  automation_status: AutomationStatus;
+  priority: Priority | null;
+}
+
+/** Full case detail with steps. */
+export interface TestCaseDetail {
+  display_id: string;
+  suite: SuiteRef;
+  title: string;
+  precondition: string | null;
+  description: string | null;
+  priority: Priority | null;
+  automation_status: AutomationStatus;
+  type: string;
+  platform_tags: PlatformTag[];
+  tags: string[];
+  steps: Step[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListTestCasesResult {
+  items: TestCaseListItem[];
+  total: number;
+  has_more: boolean;
+}
+
+/** Dry-run result for create. */
+export interface CreateDryRunResult {
+  dry_run: true;
+  would_create: Omit<CreateTestCaseInput, 'dry_run'> & { steps: Array<StepInput & { step_number: number }> };
+  summary_markdown: string;
+}
+
+/** Field diff entry for update dry-run. */
+export type FieldDiff = Record<string, { before: unknown; after: unknown }>;
+
+/** Dry-run result for update. */
+export interface UpdateDryRunResult {
+  dry_run: true;
+  display_id: string;
+  diff: FieldDiff;
+  steps_before: Step[];
+  steps_after: Array<StepInput & { step_number: number }> | null;
+  summary_markdown: string;
+}
+
+// ─── Error ────────────────────────────────────────────────────────────────────
+
+export type ErrorCode = 'NOT_FOUND' | 'AMBIGUOUS' | 'VALIDATION' | 'IN_CICD_LOCKED' | 'AUTH_ERROR' | 'SERVER_ERROR';
+
+export interface McpError {
+  error: {
+    code: ErrorCode;
+    message: string;
+  };
+}

--- a/packages/tcm-mcp/tsconfig.json
+++ b/packages/tcm-mcp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/app/api/agent-runs/[id]/close-session/route.ts
+++ b/src/app/api/agent-runs/[id]/close-session/route.ts
@@ -44,7 +44,12 @@ export async function POST(_request: Request, context: RouteContext) {
     );
   }
 
-  // Build the webhook payload
+  // Build the webhook payload.
+  // TRUST BOUNDARY NOTE: session_key, slack_channel, and slack_thread_ts are read
+  // from the DB row — not from user-supplied request input. This is intentional:
+  // caller (operator) only supplies the run ID; all sensitive identifiers come from
+  // the server-side record. OPENCLAW_WAKE_URL must be set to a trusted, internal
+  // endpoint (not user-controllable) to prevent SSRF or session-hijack via forged payloads.
   const payload = {
     runId: run.id,
     sessionKey: run.session_key,

--- a/src/app/api/projects/[projectId]/suites/route.ts
+++ b/src/app/api/projects/[projectId]/suites/route.ts
@@ -6,17 +6,27 @@ interface RouteContext {
   params: Promise<{ projectId: string }>;
 }
 
-export async function GET(_request: Request, context: RouteContext) {
+export async function GET(request: Request, context: RouteContext) {
   const auth = await withAuth('read');
   if (!auth.ok) return auth.response;
   const { supabase } = auth.ctx;
   const { projectId } = await context.params;
 
-  const { data: suites, error } = await supabase
+  // E1 — MCP prerequisite: ?search= filter (case-insensitive match on name or prefix)
+  const { searchParams } = new URL(request.url);
+  const search = searchParams.get('search')?.trim();
+
+  let query = supabase
     .from('suites')
     .select('*')
     .eq('project_id', projectId)
     .order('position', { ascending: true });
+
+  if (search) {
+    query = query.or(`name.ilike.%${search}%,prefix.ilike.%${search}%`);
+  }
+
+  const { data: suites, error } = await query;
 
   if (error) return serverError(error.message);
 

--- a/src/app/api/test-cases/bulk/route.ts
+++ b/src/app/api/test-cases/bulk/route.ts
@@ -142,6 +142,11 @@ async function handleBulkDelete(request: Request) {
  *   not_found = IDs that don't exist at all
  */
 async function handleBulkHardDelete(request: Request) {
+  // AUTH NOTE: 'soft_delete' role is intentional here — hard delete is NOT a separate
+  // RBAC permission because it is already gated to trashed-only records by the
+  // `.not('deleted_at', 'is', null)` guard below. Only records that have already been
+  // soft-deleted by an authorized Editor+ user can be permanently removed. This avoids
+  // privilege escalation while keeping the permission model simple.
   const auth = await withAuth('soft_delete');
   if (!auth.ok) return auth.response;
   const { supabase } = auth.ctx;

--- a/src/app/api/test-cases/by-display-id/[displayId]/route.ts
+++ b/src/app/api/test-cases/by-display-id/[displayId]/route.ts
@@ -1,0 +1,322 @@
+import { NextResponse } from 'next/server';
+import { withAgentAuth, notFound, serverError, validationError } from '@/lib/api/helpers';
+import { updateTestCaseSchema } from '@/lib/validations/test-case';
+import { stepSchema } from '@/lib/validations/test-step';
+import { z } from 'zod';
+
+interface RouteContext {
+  params: Promise<{ displayId: string }>;
+}
+
+/**
+ * Shared helper: resolve a display_id to an active test case UUID.
+ * Returns null if not found or deleted.
+ */
+async function resolveDisplayId(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  displayId: string,
+): Promise<{ id: string; automation_status: string } | null> {
+  const { data, error } = await supabase
+    .from('test_cases')
+    .select('id, automation_status')
+    .eq('display_id', displayId)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data;
+}
+
+/**
+ * GET /api/test-cases/by-display-id/[displayId]
+ *
+ * E3 — MCP prerequisite: resolve display_id → full case with steps.
+ * Auth: withAgentAuth (X-Clutch-Key or Bearer Supabase JWT or session cookie).
+ */
+export async function GET(_request: Request, context: RouteContext) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  const { displayId } = await context.params;
+  const decodedDisplayId = decodeURIComponent(displayId);
+
+  const resolved = await resolveDisplayId(supabase, decodedDisplayId);
+  if (!resolved) return notFound('Test case');
+
+  const { data: testCase, error } = await supabase
+    .from('test_cases')
+    .select(`
+      *,
+      suite:suites(id, name, prefix, project_id),
+      test_steps(id, step_number, description, test_data, expected_result, is_automation_only, category)
+    `)
+    .eq('id', resolved.id)
+    .is('deleted_at', null)
+    .single();
+
+  if (error || !testCase) return notFound('Test case');
+
+  // Sort steps by step_number
+  const sortedSteps = ((testCase.test_steps ?? []) as Array<{ step_number: number }>)
+    .sort((a, b) => a.step_number - b.step_number);
+
+  return NextResponse.json({
+    display_id: testCase.display_id,
+    suite: testCase.suite,
+    title: testCase.title,
+    precondition: testCase.precondition,
+    description: testCase.description,
+    priority: testCase.priority,
+    automation_status: testCase.automation_status,
+    type: testCase.type,
+    platform_tags: testCase.platform_tags,
+    tags: testCase.tags,
+    steps: sortedSteps,
+    created_at: testCase.created_at,
+    updated_at: testCase.updated_at,
+  });
+}
+
+// MCP v1 update schema — constrained enum surface per PRD §7 / OQ-5
+const mcpUpdateBodySchema = updateTestCaseSchema
+  .omit({ display_id: true, suite_id: true })
+  .extend({
+    // v1: priority only low/medium/high/null (critical deferred)
+    priority: z.enum(['low', 'medium', 'high']).nullable().optional(),
+    // v1: type not exposed; steps full-replace if provided
+    steps: z
+      .array(
+        stepSchema.omit({ step_number: true }).extend({
+          // step_number will be assigned by array order (1-based)
+          step_number: z.number().int().min(1).optional(),
+        }),
+      )
+      .optional(),
+    dry_run: z.boolean().optional().default(false),
+  });
+
+/**
+ * PATCH /api/test-cases/by-display-id/[displayId]
+ *
+ * E5 — MCP prerequisite: partial update by display_id with optional steps full-replace.
+ * Supports ?dry_run=true query param (OQ-6 Option B).
+ * Auth: withAgentAuth.
+ */
+export async function PATCH(request: Request, context: RouteContext) {
+  const auth = await withAgentAuth();
+  if (!auth.ok) return auth.response;
+  const { supabase } = auth;
+
+  const { displayId } = await context.params;
+  const decodedDisplayId = decodeURIComponent(displayId);
+
+  // OQ-6: also support ?dry_run=true query param
+  const { searchParams } = new URL(request.url);
+  const queryDryRun = searchParams.get('dry_run') === 'true';
+
+  const body = await request.json();
+  const parsed = mcpUpdateBodySchema.safeParse(body);
+  if (!parsed.success) return validationError(parsed.error.flatten());
+
+  const dryRun = parsed.data.dry_run || queryDryRun;
+
+  // Resolve display_id → UUID (active rows only)
+  const resolved = await resolveDisplayId(supabase, decodedDisplayId);
+  if (!resolved) return notFound('Test case');
+
+  // IN_CICD_LOCKED: display_id changes not accepted (tool docs say don't pass it,
+  // but guard anyway — any attempt implies rename intent)
+  // For in_cicd cases, reject any attempted display_id change (though schema omits it,
+  // also reject if automation_status is being changed away from in_cicd illegally).
+  // The real lock is: don't accept display_id changes — enforced by schema omit above.
+
+  // Fetch existing case + steps for diff / before-state
+  const { data: existing, error: fetchErr } = await supabase
+    .from('test_cases')
+    .select(`
+      *,
+      suite:suites(id, name, prefix, project_id),
+      test_steps(id, step_number, description, test_data, expected_result, is_automation_only, category)
+    `)
+    .eq('id', resolved.id)
+    .is('deleted_at', null)
+    .single();
+
+  if (fetchErr || !existing) return notFound('Test case');
+
+  const existingSteps = ((existing.test_steps ?? []) as Array<{ step_number: number }>)
+    .sort((a, b) => a.step_number - b.step_number);
+
+  // Compute field diff for dry-run response
+  const { steps: newSteps, dry_run: _dryRun, ...caseUpdates } = parsed.data;
+
+  // Log to mcp_tool_calls table (instrumentation — Appendix C)
+  const correlationId = request.headers.get('x-mcp-correlation-id') ?? null;
+  const intent = request.headers.get('x-mcp-intent') ?? (dryRun ? 'dry-run-update' : 'commit-update');
+  const actorIdentity = request.headers.get('x-clutch-key')
+    ? 'clutch-key'
+    : request.headers.get('authorization')
+      ? 'bearer-jwt'
+      : 'session';
+
+  await supabase.from('mcp_tool_calls').insert({
+    correlation_id: correlationId,
+    tool: 'update_test_case',
+    dry_run: dryRun,
+    intent,
+    actor_identity: actorIdentity,
+    resolved_display_id: decodedDisplayId,
+    suite_id: existing.suite_id,
+    outcome: 'pending',
+  }).then(() => {}); // fire-and-forget, don't block response
+
+  if (dryRun) {
+    // Compute before/after diff for case fields
+    const fieldDiff: Record<string, { before: unknown; after: unknown }> = {};
+    for (const [key, value] of Object.entries(caseUpdates)) {
+      const before = (existing as Record<string, unknown>)[key];
+      if (JSON.stringify(before) !== JSON.stringify(value)) {
+        fieldDiff[key] = { before, after: value };
+      }
+    }
+
+    // Compute proposed steps (assign step_number by order)
+    const proposedSteps = newSteps
+      ? newSteps.map((s, i) => ({ ...s, step_number: i + 1 }))
+      : null;
+
+    // Build human-readable markdown summary
+    const summaryLines: string[] = [
+      `## Dry-run: update \`${decodedDisplayId}\``,
+      '',
+      '### Field changes',
+    ];
+    if (Object.keys(fieldDiff).length === 0) {
+      summaryLines.push('_No field changes_');
+    } else {
+      for (const [field, { before, after }] of Object.entries(fieldDiff)) {
+        summaryLines.push(`- **${field}**: \`${JSON.stringify(before)}\` → \`${JSON.stringify(after)}\``);
+      }
+    }
+
+    if (proposedSteps !== null) {
+      summaryLines.push('', '### Steps (full replace)');
+      summaryLines.push('**Before:**');
+      for (const s of existingSteps as Array<Record<string, unknown>>) {
+        summaryLines.push(`  ${s.step_number}. ${s.description}`);
+      }
+      summaryLines.push('**After:**');
+      for (const s of proposedSteps) {
+        summaryLines.push(`  ${s.step_number}. ${s.description}`);
+      }
+    }
+
+    // Update mcp_tool_calls outcome
+    await supabase.from('mcp_tool_calls').update({ outcome: 'dry_run_returned' })
+      .eq('correlation_id', correlationId ?? '')
+      .then(() => {});
+
+    return NextResponse.json({
+      dry_run: true,
+      display_id: decodedDisplayId,
+      diff: fieldDiff,
+      steps_before: existingSteps,
+      steps_after: proposedSteps,
+      summary_markdown: summaryLines.join('\n'),
+    });
+  }
+
+  // Commit path — apply partial update
+  const updatePayload: Record<string, unknown> = { ...caseUpdates };
+
+  if (Object.keys(updatePayload).length === 0 && !newSteps) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  let updatedCase: Record<string, unknown> | null = null;
+
+  if (Object.keys(updatePayload).length > 0) {
+    const { data, error: updateErr } = await supabase
+      .from('test_cases')
+      .update(updatePayload)
+      .eq('id', resolved.id)
+      .is('deleted_at', null)
+      .select()
+      .single();
+
+    if (updateErr || !data) return serverError(updateErr?.message ?? 'Failed to update test case');
+    updatedCase = data as Record<string, unknown>;
+  } else {
+    updatedCase = existing as Record<string, unknown>;
+  }
+
+  // Steps full-replace if provided
+  if (newSteps !== undefined) {
+    const { error: deleteErr } = await supabase
+      .from('test_steps')
+      .delete()
+      .eq('test_case_id', resolved.id);
+
+    if (deleteErr) return serverError(deleteErr.message);
+
+    if (newSteps.length > 0) {
+      const stepRows = newSteps.map((s, i) => ({
+        test_case_id: resolved.id,
+        step_number: i + 1,
+        description: s.description,
+        test_data: s.test_data ?? null,
+        expected_result: s.expected_result ?? null,
+        is_automation_only: s.is_automation_only ?? false,
+        category: s.category ?? null,
+      }));
+
+      const { error: insertErr } = await supabase
+        .from('test_steps')
+        .insert(stepRows);
+
+      if (insertErr) return serverError(insertErr.message);
+    }
+  }
+
+  // Fetch updated case with full relations for response
+  const { data: finalCase, error: finalErr } = await supabase
+    .from('test_cases')
+    .select(`
+      *,
+      suite:suites(id, name, prefix, project_id),
+      test_steps(id, step_number, description, test_data, expected_result, is_automation_only, category)
+    `)
+    .eq('id', resolved.id)
+    .is('deleted_at', null)
+    .single();
+
+  if (finalErr || !finalCase) return serverError('Failed to fetch updated test case');
+
+  const sortedFinalSteps = ((finalCase.test_steps ?? []) as Array<{ step_number: number }>)
+    .sort((a, b) => a.step_number - b.step_number);
+
+  // Update mcp_tool_calls outcome
+  await supabase.from('mcp_tool_calls').update({ outcome: 'success' })
+    .eq('correlation_id', correlationId ?? '')
+    .then(() => {});
+
+  return NextResponse.json({
+    display_id: finalCase.display_id,
+    suite: finalCase.suite,
+    title: finalCase.title,
+    precondition: finalCase.precondition,
+    description: finalCase.description,
+    priority: finalCase.priority,
+    automation_status: finalCase.automation_status,
+    type: finalCase.type,
+    platform_tags: finalCase.platform_tags,
+    tags: finalCase.tags,
+    steps: sortedFinalSteps,
+    created_at: finalCase.created_at,
+    updated_at: finalCase.updated_at,
+  });
+}
+
+

--- a/src/app/api/test-cases/by-display-id/[displayId]/route.ts
+++ b/src/app/api/test-cases/by-display-id/[displayId]/route.ts
@@ -112,6 +112,18 @@ export async function PATCH(request: Request, context: RouteContext) {
   const { displayId } = await context.params;
   const decodedDisplayId = decodeURIComponent(displayId);
 
+  // Resolve userId for updated_by attribution (OQ-2)
+  let userId: string | null = null;
+  const authHeader = request.headers.get('authorization') ?? '';
+  if (authHeader.startsWith('Bearer ')) {
+    const { data } = await supabase.auth.getUser(authHeader.slice(7));
+    userId = data.user?.id ?? null;
+  }
+  // Headless Clutch-key path: fall back to dedicated agent profile
+  if (!userId && process.env.MCP_AGENT_USER_ID) {
+    userId = process.env.MCP_AGENT_USER_ID;
+  }
+
   // OQ-6: also support ?dry_run=true query param
   const { searchParams } = new URL(request.url);
   const queryDryRun = searchParams.get('dry_run') === 'true';
@@ -230,6 +242,8 @@ export async function PATCH(request: Request, context: RouteContext) {
 
   // Commit path — apply partial update
   const updatePayload: Record<string, unknown> = { ...caseUpdates };
+  // Set updated_by for attribution (OQ-2)
+  if (userId) updatePayload.updated_by = userId;
 
   if (Object.keys(updatePayload).length === 0 && !newSteps) {
     return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });

--- a/src/app/api/test-cases/route.ts
+++ b/src/app/api/test-cases/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from 'next/server';
-import { withAuth, validationError, serverError } from '@/lib/api/helpers';
+import { withAuth, withAgentAuth, validationError, serverError } from '@/lib/api/helpers';
 import { createTestCaseSchema } from '@/lib/validations/test-case';
+import { stepSchema } from '@/lib/validations/test-step';
 import { TestCaseRepository } from '@/lib/db/test-case-repository';
+import { z } from 'zod';
+
+// E2 list filter extensions
+const LIST_LIMIT_DEFAULT = 50;
+const LIST_LIMIT_MAX = 200;
 
 export async function GET(request: Request) {
   const auth = await withAuth('read');
@@ -55,16 +61,28 @@ export async function GET(request: Request) {
     }
   }
 
+  // E2 — MCP prerequisite: project_id filter + limit clamp
+  const projectId = searchParams.get('project_id')?.trim();
+  const limitParam = searchParams.get('limit');
+  const rawLimit = limitParam ? parseInt(limitParam, 10) : LIST_LIMIT_DEFAULT;
+  const clampedLimit = Math.min(isNaN(rawLimit) || rawLimit < 1 ? LIST_LIMIT_DEFAULT : rawLimit, LIST_LIMIT_MAX);
+  const limitClamped = limitParam && rawLimit > LIST_LIMIT_MAX;
+
   // Text search applied in-memory (the supabase client query is constructed in findAll)
   // For search we need to re-query with ilike — fall through to direct query below
-  if (search) {
-    // Re-query with search filter directly (repository doesn't support ilike yet)
-    const { data, error } = await supabase
+  if (search || projectId) {
+    // Re-query with search/project_id filter directly
+    let q = supabase
       .from('test_cases')
-      .select('*, suite:suites(project_id)')
+      .select('*, suite:suites!inner(project_id)')
       .is('deleted_at', null)
-      .or(`display_id.ilike.%${search}%,title.ilike.%${search}%`)
-      .order('position', { ascending: true });
+      .order('position', { ascending: true })
+      .limit(clampedLimit);
+    if (search) q = q.or(`display_id.ilike.%${search}%,title.ilike.%${search}%`);
+    if (suiteId) q = q.eq('suite_id', suiteId);
+    // project_id filter via inner join on suites
+    if (projectId) q = q.eq('suites.project_id', projectId);
+    const { data, error } = await q;
     if (error) return serverError(error.message);
     testCases = data ?? [];
   }
@@ -165,27 +183,146 @@ export async function GET(request: Request) {
     }
   }
 
+  // Apply limit if no search/projectId path was taken
+  if (!search && !projectId && clampedLimit < testCases.length) {
+    testCases = testCases.slice(0, clampedLimit);
+  }
+
+  const total = testCases.length;
+  const has_more = limitClamped;
+
+  // If lean projection requested (MCP path), return minimal fields
+  const lean = searchParams.get('fields') === 'lean';
+  if (lean) {
+    return NextResponse.json({
+      items: testCases.map((tc) => ({
+        display_id: tc.display_id,
+        title: tc.title,
+        automation_status: tc.automation_status,
+        priority: tc.priority,
+      })),
+      total,
+      has_more,
+    });
+  }
+
   return NextResponse.json(testCases);
 }
 
-export async function POST(request: Request) {
-  const auth = await withAuth('write');
-  if (!auth.ok) return auth.response;
-  const { supabase, user } = auth.ctx;
+// E4 body schema: createTestCaseSchema extended with optional steps[] and dry_run
+const createWithStepsSchema = createTestCaseSchema.extend({
+  steps: z
+    .array(
+      stepSchema.omit({ step_number: true }).extend({
+        step_number: z.number().int().min(1).optional(),
+      }),
+    )
+    .optional(),
+  dry_run: z.boolean().optional().default(false),
+});
 
-  const body = await request.json();
-  const parsed = createTestCaseSchema.safeParse(body);
+export async function POST(request: Request) {
+  // Accept both agent auth (X-Clutch-Key / Bearer JWT) and normal session auth.
+  // Try agent auth first so headless agents (Torque via Clutch) can create cases.
+  // E4 extension: accepts optional steps[] for atomic insert + dry_run support (OQ-6 Option B).
+  const rawBody = await request.json();
+
+  // Detect if this is an MCP call (has steps or dry_run field)
+  const isMcpCall = 'steps' in rawBody || 'dry_run' in rawBody;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let supabase: any;
+  let userId: string | null = null;
+
+  if (isMcpCall) {
+    // Agent auth path for MCP callers
+    const agentAuth = await withAgentAuth();
+    if (!agentAuth.ok) return agentAuth.response;
+    supabase = agentAuth.supabase;
+    // Try to resolve user from Bearer token for attribution (OQ-2)
+    const authHeader = request.headers.get('authorization') ?? '';
+    if (authHeader.startsWith('Bearer ')) {
+      const { data } = await supabase.auth.getUser(authHeader.slice(7));
+      userId = data.user?.id ?? null;
+    }
+  } else {
+    // Normal session auth for UI callers
+    const auth = await withAuth('write');
+    if (!auth.ok) return auth.response;
+    supabase = auth.ctx.supabase;
+    userId = auth.ctx.user.id;
+  }
+
+  // Parse with extended schema (supports steps + dry_run) or basic schema
+  const parsed = isMcpCall
+    ? createWithStepsSchema.safeParse(rawBody)
+    : createTestCaseSchema.extend({ steps: z.never().optional(), dry_run: z.never().optional() }).safeParse(rawBody);
+
   if (!parsed.success) return validationError(parsed.error.flatten());
+  const data = parsed.data as z.infer<typeof createWithStepsSchema>;
+
+  // OQ-6: dry_run support — validate + summarize, no write
+  const queryDryRun = new URL(request.url).searchParams.get('dry_run') === 'true';
+  const dryRun = data.dry_run || queryDryRun;
+
+  if (dryRun) {
+    // Log dry-run attempt
+    const correlationId = request.headers.get('x-mcp-correlation-id') ?? null;
+    const actorIdentity = request.headers.get('x-clutch-key') ? 'clutch-key' : 'bearer-jwt';
+    await supabase.from('mcp_tool_calls').insert({
+      correlation_id: correlationId,
+      tool: 'create_test_case',
+      dry_run: true,
+      intent: request.headers.get('x-mcp-intent') ?? 'dry-run-create',
+      actor_identity: actorIdentity,
+      suite_id: data.suite_id,
+      outcome: 'dry_run_returned',
+    }).then(() => {});
+
+    const proposedSteps = data.steps
+      ? data.steps.map((s, i) => ({ ...s, step_number: i + 1 }))
+      : [];
+
+    // Fetch suite prefix for summary (display_id assigned on commit)
+    const { data: suite } = await supabase
+      .from('suites')
+      .select('prefix, name')
+      .eq('id', data.suite_id)
+      .single();
+
+    const summaryLines = [
+      '## Dry-run: create test case',
+      '',
+      `**Suite:** ${suite?.name ?? data.suite_id} (prefix: ${suite?.prefix ?? '?'})`,
+      `**Title:** ${data.title}`,
+      `**Priority:** ${data.priority ?? 'null'}`,
+      `**Automation status:** ${data.automation_status ?? 'not_automated'}`,
+      `**Platform tags:** ${(data.platform_tags ?? []).join(', ') || 'none'}`,
+      '',
+      '_display_id will be assigned on commit_',
+      '',
+      `**Steps (${proposedSteps.length}):**`,
+      ...proposedSteps.map((s) => `  ${s.step_number}. ${s.description}`),
+    ];
+
+    return NextResponse.json({
+      dry_run: true,
+      would_create: { ...data, steps: proposedSteps },
+      summary_markdown: summaryLines.join('\n'),
+    });
+  }
+
+  // --- Commit path ---
 
   // Duplicate-name notice: check if a deleted case with the same title exists
   const repo = new TestCaseRepository(supabase);
-  const deletedMatches = await repo.findDeletedByTitle(parsed.data.title, parsed.data.suite_id);
+  const deletedMatches = await repo.findDeletedByTitle(data.title, data.suite_id);
   const duplicateNotice = deletedMatches.length > 0
-    ? `A deleted test case named "${parsed.data.title}" exists in the trash. You can restore it instead.`
+    ? `A deleted test case named "${data.title}" exists in the trash. You can restore it instead.`
     : null;
 
   const { data: idResult, error: rpcError } = await supabase
-    .rpc('generate_test_case_id', { p_suite_id: parsed.data.suite_id })
+    .rpc('generate_test_case_id', { p_suite_id: data.suite_id })
     .single();
 
   if (rpcError || !idResult) {
@@ -198,7 +335,7 @@ export async function POST(request: Request) {
   const { data: maxPosRow } = await supabase
     .from('test_cases')
     .select('position')
-    .eq('suite_id', parsed.data.suite_id)
+    .eq('suite_id', data.suite_id)
     .is('deleted_at', null)
     .order('position', { ascending: false })
     .limit(1)
@@ -209,28 +346,75 @@ export async function POST(request: Request) {
   const { data: testCase, error } = await supabase
     .from('test_cases')
     .insert({
-      suite_id: parsed.data.suite_id,
+      suite_id: data.suite_id,
       display_id,
       sequence_number,
-      title: parsed.data.title,
-      description: parsed.data.description ?? null,
-      precondition: parsed.data.precondition ?? null,
-      type: parsed.data.type,
-      automation_status: parsed.data.automation_status,
-      platform_tags: parsed.data.platform_tags,
-      priority: parsed.data.priority ?? null,
-      tags: parsed.data.tags,
+      title: data.title,
+      description: data.description ?? null,
+      precondition: data.precondition ?? null,
+      type: data.type,
+      automation_status: data.automation_status,
+      platform_tags: data.platform_tags,
+      priority: data.priority ?? null,
+      tags: data.tags,
       position: nextPosition,
-      created_by: user.id,
-      updated_by: user.id,
+      created_by: userId,
+      updated_by: userId,
     })
     .select()
     .single();
 
   if (error) return serverError(error.message);
 
+  // E4 extension: atomically insert steps if provided
+  let insertedSteps: unknown[] = [];
+  if (data.steps && data.steps.length > 0 && testCase) {
+    const stepRows = data.steps.map((s, i) => ({
+      test_case_id: testCase.id,
+      step_number: i + 1,
+      description: s.description,
+      test_data: s.test_data ?? null,
+      expected_result: s.expected_result ?? null,
+      is_automation_only: s.is_automation_only ?? false,
+      category: s.category ?? null,
+    }));
+
+    const { data: steps, error: stepsErr } = await supabase
+      .from('test_steps')
+      .insert(stepRows)
+      .select()
+      .order('step_number', { ascending: true });
+
+    if (stepsErr) {
+      // Compensate: delete the case if steps insert fails (maintain atomicity)
+      await supabase.from('test_cases').delete().eq('id', testCase.id);
+      return serverError(stepsErr.message);
+    }
+    insertedSteps = steps ?? [];
+  }
+
+  // Log MCP commit call
+  if (isMcpCall) {
+    const correlationId = request.headers.get('x-mcp-correlation-id') ?? null;
+    const actorIdentity = request.headers.get('x-clutch-key') ? 'clutch-key' : 'bearer-jwt';
+    await supabase.from('mcp_tool_calls').insert({
+      correlation_id: correlationId,
+      tool: 'create_test_case',
+      dry_run: false,
+      intent: request.headers.get('x-mcp-intent') ?? 'commit-create',
+      actor_identity: actorIdentity,
+      resolved_display_id: display_id,
+      suite_id: data.suite_id,
+      outcome: 'success',
+    }).then(() => {});
+  }
+
   return NextResponse.json(
-    { ...testCase, ...(duplicateNotice ? { notice: duplicateNotice } : {}) },
+    {
+      ...testCase,
+      steps: insertedSteps,
+      ...(duplicateNotice ? { notice: duplicateNotice } : {}),
+    },
     { status: 201 },
   );
 }

--- a/src/app/api/test-cases/route.ts
+++ b/src/app/api/test-cases/route.ts
@@ -245,6 +245,10 @@ export async function POST(request: Request) {
       const { data } = await supabase.auth.getUser(authHeader.slice(7));
       userId = data.user?.id ?? null;
     }
+    // Headless Clutch-key path: fall back to dedicated agent profile
+    if (!userId && process.env.MCP_AGENT_USER_ID) {
+      userId = process.env.MCP_AGENT_USER_ID;
+    }
   } else {
     // Normal session auth for UI callers
     const auth = await withAuth('write');

--- a/supabase/migrations/00042_mcp_tool_calls.sql
+++ b/supabase/migrations/00042_mcp_tool_calls.sql
@@ -1,0 +1,60 @@
+-- Migration 00042: mcp_tool_calls instrumentation table
+--
+-- One row per MCP tool call proxied through TCM REST endpoints.
+-- Enables measurement of the four MCP success signals (PRD §3, Appendix C):
+--   - Reliability: agent PostgREST traffic vs. MCP traffic
+--   - Safety: commits preceded by a matched dry-run (correlation_id + payload_hash)
+--   - Data quality: validation rejection count vs. successful writes
+--   - Schema resilience: error-rate across deploys
+--
+-- Written at the REST boundary (server-side), so it cannot be skipped by a
+-- misbehaving agent. This is the central audit log for the dry-run → approval
+-- → commit flow (OQ-4 Option A accepted risk measurement).
+
+CREATE TABLE mcp_tool_calls (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Groups dry-run and its matching commit in the same agent session.
+  -- Stamped by the MCP client as X-MCP-Correlation-Id.
+  correlation_id text,
+
+  -- Which MCP tool was called:
+  -- search_suite | list_test_cases | get_test_case | create_test_case | update_test_case
+  tool text NOT NULL,
+
+  -- Whether this was a dry-run (no write) or a commit call.
+  dry_run boolean NOT NULL DEFAULT false,
+
+  -- Human-readable intent tag: e.g. 'dry-run-create', 'commit-update', 'dry-run-update'.
+  -- Stamped by the MCP client as X-MCP-Intent.
+  intent text,
+
+  -- Identifies the caller: 'clutch-key' (headless Torque path) or 'bearer-jwt' (Claude Code path).
+  actor_identity text,
+
+  -- The resolved display_id targeted by the call (for case tools).
+  resolved_display_id text,
+
+  -- The suite_id involved (for suite and case tools).
+  suite_id uuid,
+
+  -- SHA-256 hash of the normalized write payload.
+  -- Lets us verify a commit payload matches its approved dry-run payload.
+  payload_hash text,
+
+  -- Outcome of the call: 'success' | 'dry_run_returned' | 'validation_error' |
+  -- 'not_found' | 'in_cicd_locked' | 'ambiguous' | 'pending' | 'error'
+  outcome text,
+
+  -- Structured error code if outcome is an error: NOT_FOUND | AMBIGUOUS |
+  -- VALIDATION | IN_CICD_LOCKED
+  error_code text,
+
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for joining dry-run → commit in the same session
+CREATE INDEX mcp_tool_calls_correlation_id_idx ON mcp_tool_calls (correlation_id);
+
+-- Index for time-range queries and recent-call dashboards
+CREATE INDEX mcp_tool_calls_created_at_idx ON mcp_tool_calls (created_at DESC);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "packages"
   ]
 }


### PR DESCRIPTION
## Summary

Lands **MCP Epic 1 — Test Case CRUD** on `main`: MCP tools giving AI agents (Torque, triage-e2e, Claude agents) structured, safe access to TCM test cases, replacing raw Supabase REST access.

> **Note on scope:** this PR started as PRD-only, but **PR #103 (implementation) was merged into this branch** rather than `main`. So this branch now carries **both the PRD and the full implementation** — merging it is what ships the whole epic to `main`. (`main` currently has neither.)

## Contents

### 1. PRD — `docs/features/mcp-e1-test-case-crud.md`
Five tools (`search_suite`, `list_test_cases`, `get_test_case`, `create_test_case`, `update_test_case`) with the dry-run → human-approval → commit flow (MCP returns the summary; the agent delivers it — Clutch→Slack for headless, inline chat for Claude Code). Decisions: no `change_reason` (OQ-1); two auth modes — Clutch key / user token (OQ-2); `npx` local stdio, git-URL distribution, thin client proxying TCM REST (OQ-3); process-only approval (OQ-4); narrow enum surface, defer to v2 (OQ-5). Appendix B specs the prerequisite `display_id`-keyed REST surface; Appendix C the `mcp_tool_calls` instrumentation.

### 2. REST prerequisites (Appendix B)
- **E1** `GET /api/projects/[projectId]/suites?search=` — suite lookup (extend)
- **E2** `GET /api/test-cases?project_id=&limit=&fields=lean` — list (extend); `{items,total,has_more}`
- **E3** `GET /api/test-cases/by-display-id/[displayId]` — get by display_id (new)
- **E4** `POST /api/test-cases` — inline `steps[]` + `dry_run` (extend)
- **E5** `PATCH /api/test-cases/by-display-id/[displayId]` — partial update + steps full-replace + `dry_run` (new)

Reads/resolution are active-scoped — **trashed (soft-deleted) cases are excluded from get and list** (verified in code: `resolveDisplayId` + detail fetch both filter `deleted_at IS NULL`; list uses the active-scope repository / explicit filter).

### 3. MCP server package — `packages/tcm-mcp/`
Thin stdio client proxying the REST surface; two-mode auth (`CLUTCH_API_KEY` / `TCM_USER_TOKEN`); stamps `X-MCP-Correlation-Id` / `X-MCP-Intent` for audit; all 5 tools per PRD §8.

### 4. Other
- `.mcp.json` — `tcm` MCP server entry (git-URL distribution, no npm publish)
- `supabase/migrations/00042_mcp_tool_calls.sql` — instrumentation table (Appendix C)
- `created_by`/`updated_by` attribution for the headless path wired via `MCP_AGENT_USER_ID` (OQ-2 residual)

## Open items before merge
- **Migration 00042 not yet applied** to the shared Supabase project — until then, `mcp_tool_calls` inserts silently no-op (fire-and-forget; non-blocking, so the tools still work). Applying it affects the shared DB, not preview-only.
- **`packages/tcm-mcp` not built in CI** — compiles with its own `tsc`; consider a `build:mcp` step.
- **Git-URL distribution** needs a `prepare` build (TS→JS) or committed `dist/`.
- Browser/UI testing on the preview is blocked by Supabase OAuth redirect allowlist (ephemeral preview URL); server-to-server testing needs a Vercel protection-bypass secret + test Clutch key.

Supersedes the PRD-only scope of this PR; incorporates #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)