### PR TITLE
fix(mcp): make agent auth reach Test Case CRUD routes

### DIFF
--- a/packages/tcm-mcp/src/client.ts
+++ b/packages/tcm-mcp/src/client.ts
@@ -30,7 +30,12 @@ export class TcmClient {
 
   /**
    * Make a request to TCM REST API.
-   * Throws on network failure; returns parsed JSON on success or HTTP error.
+   *
+   * Never throws: a network-level failure (DNS, connection refused, TLS, timeout) is
+   * returned as { ok: false, status: 0 } so callers surface a structured tool error
+   * instead of a raw MCP -32603. Redirects are NOT followed — TCM's auth middleware
+   * 307-redirects unauthenticated requests to /login; following it would yield a 200
+   * HTML page and mask the real failure, so the 3xx is surfaced as a non-ok status.
    */
   async request<T = unknown>(
     path: string,
@@ -42,11 +47,18 @@ export class TcmClient {
     if (correlationId) headers['X-MCP-Correlation-Id'] = correlationId;
     if (intent) headers['X-MCP-Intent'] = intent;
 
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      method,
-      headers,
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    });
+    let res: Response;
+    try {
+      res = await fetch(`${this.baseUrl}${path}`, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        redirect: 'manual',
+      });
+    } catch {
+      // Network-level failure — surface as a non-ok result rather than throwing.
+      return { ok: false, status: 0, data: null as unknown as T };
+    }
 
     let data: T;
     try {

--- a/src/app/api/projects/[projectId]/suites/route.ts
+++ b/src/app/api/projects/[projectId]/suites/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { withAuth, validationError, serverError, conflict } from '@/lib/api/helpers';
+import { withAuth, withAgentAuth, validationError, serverError, conflict } from '@/lib/api/helpers';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSuiteSchema } from '@/lib/validations/suite';
 
 interface RouteContext {
@@ -7,9 +8,22 @@ interface RouteContext {
 }
 
 export async function GET(request: Request, context: RouteContext) {
-  const auth = await withAuth('read');
-  if (!auth.ok) return auth.response;
-  const { supabase } = auth.ctx;
+  // Dual auth: agents (X-Clutch-Key or Bearer JWT) authenticate via withAgentAuth so the MCP
+  // search_suite tool can reach this route; browser/session callers keep withAuth('read').
+  const isAgentCall =
+    request.headers.get('x-clutch-key') !== null ||
+    (request.headers.get('authorization') ?? '').startsWith('Bearer ');
+
+  let supabase: SupabaseClient;
+  if (isAgentCall) {
+    const agentAuth = await withAgentAuth();
+    if (!agentAuth.ok) return agentAuth.response;
+    supabase = agentAuth.supabase;
+  } else {
+    const auth = await withAuth('read');
+    if (!auth.ok) return auth.response;
+    supabase = auth.ctx.supabase;
+  }
   const { projectId } = await context.params;
 
   // E1 — MCP prerequisite: ?search= filter (case-insensitive match on name or prefix)

--- a/src/app/api/test-cases/route.ts
+++ b/src/app/api/test-cases/route.ts
@@ -4,15 +4,32 @@ import { createTestCaseSchema } from '@/lib/validations/test-case';
 import { stepSchema } from '@/lib/validations/test-step';
 import { TestCaseRepository } from '@/lib/db/test-case-repository';
 import { z } from 'zod';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 // E2 list filter extensions
 const LIST_LIMIT_DEFAULT = 50;
 const LIST_LIMIT_MAX = 200;
 
 export async function GET(request: Request) {
-  const auth = await withAuth('read');
-  if (!auth.ok) return auth.response;
-  const { supabase, role } = auth.ctx;
+  // Dual auth: agents (X-Clutch-Key or Bearer JWT) authenticate via withAgentAuth so the MCP
+  // list_test_cases tool can reach this route; browser/session callers keep withAuth('read')
+  // (RLS-scoped client + role checks). Mirrors the create (POST) handler below.
+  const isAgentCall =
+    request.headers.get('x-clutch-key') !== null ||
+    (request.headers.get('authorization') ?? '').startsWith('Bearer ');
+
+  let supabase: SupabaseClient;
+  let role: string | null = null;
+  if (isAgentCall) {
+    const agentAuth = await withAgentAuth();
+    if (!agentAuth.ok) return agentAuth.response;
+    supabase = agentAuth.supabase;
+  } else {
+    const auth = await withAuth('read');
+    if (!auth.ok) return auth.response;
+    supabase = auth.ctx.supabase;
+    role = auth.ctx.role;
+  }
 
   const { searchParams } = new URL(request.url);
   const suiteId = searchParams.get('suite_id');
@@ -24,9 +41,10 @@ export async function GET(request: Request) {
 
   const repo = new TestCaseRepository(supabase);
 
-  // Trash view — Editor+ only (403 for Viewers)
+  // Trash view — Editor+ only (403 for Viewers). Agents cannot reach trash via this route
+  // (MCP reads exclude soft-deleted cases); role is only populated on the session path.
   if (deleted) {
-    if (role === 'viewer') {
+    if (isAgentCall || role === 'viewer') {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
     const filters: Record<string, unknown> = {};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,6 +11,15 @@ const PUBLIC_PATHS = [
   '/api/feedback/projects',    // public project list for form dropdown
   '/api/agent-runs',           // dual-auth: Bearer token (Clutch) or session cookie
   '/api/cron/',                // internal cron endpoints
+  // Agent-reachable API routes for the MCP (Test Case CRUD). These handlers authenticate
+  // header-based agent auth (X-Clutch-Key / Bearer JWT) themselves via withAgentAuth.
+  // Middleware only inspects the cookie session, so without exempting them it would
+  // 307-redirect agent (no-cookie) requests to /login before the handler runs. Browser
+  // users are unaffected (they carry a cookie); unauthenticated requests get a 401/403
+  // from the handler instead of a redirect. The /api/projects/*/suites route is matched
+  // separately below -- its dynamic segment can't be a startsWith prefix without also
+  // exempting every other /api/projects route.
+  '/api/test-cases',           // list + create, and .../by-display-id get + update
 ];
 
 export async function middleware(request: NextRequest) {
@@ -48,7 +57,9 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isPublicPath =
     PUBLIC_PATHS.some((p) => pathname.startsWith(p)) ||
-    (pathname === '/api/feedback' && request.method === 'POST');
+    (pathname === '/api/feedback' && request.method === 'POST') ||
+    // MCP search_suite -> GET /api/projects/{id}/suites. Handler does agent auth (withAgentAuth).
+    /^\/api\/projects\/[^/]+\/suites$/.test(pathname);
 
   if (!user && !isPublicPath) {
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## Problem

The tcm-mcp server's 5 tools are **non-functional against the deployed app** — verified live against `tcm-ochre.vercel.app`. Two server-side gaps (both in the merged Epic 1 impl), plus one MCP client quality bug:

1. **Middleware gate blocks all 5 tools.** `src/middleware.ts` runs on every non-static path and 307-redirects any request **without a cookie session** to `/login` *before* the route handler runs. It only reads the cookie session (`supabase.auth.getUser()`) — it never inspects the `X-Clutch-Key` / `Authorization: Bearer` headers agents send. `PUBLIC_PATHS` did not include `/api/test-cases` or `/api/projects/*/suites`.
   - Proof: same URL → **200 JSON with a cookie**, **307 → /login with a valid Bearer JWT**.
2. **Two handlers are cookie-only.** `GET /api/test-cases` (list) and `GET /api/projects/[projectId]/suites` used `withAuth('read')` (cookie SSR client only), not `withAgentAuth`. So even past the middleware they'd 401 an agent. (`by-display-id` GET/PATCH and the `create` POST already use `withAgentAuth`.)
3. **MCP client masks failures.** On a network failure or a followed 307→/login, tools surfaced a raw JSON-RPC `-32603 "fetch failed"` (protocol error, `isError:false`) instead of a structured `{error:{code,message}}`.

## Changes

- **`src/middleware.ts`** — exempt `/api/test-cases` and (via a targeted regex) `/api/projects/*/suites` from the cookie redirect. These handlers self-authenticate via `withAgentAuth`, matching the existing `/api/agent-runs` precedent.
- **`GET /api/test-cases`** and **`GET /api/projects/[projectId]/suites`** — dual-path auth: agents (`X-Clutch-Key` / `Bearer`) → `withAgentAuth`; browser/session callers → `withAuth('read')` (unchanged). Mirrors the existing `create` (POST) handler. Agents are denied the trash view.
- **`packages/tcm-mcp/src/client.ts`** — never throw on network failure (return `{ok:false, status:0}`); stop following redirects (`redirect: 'manual'`) so a 307 surfaces as a non-ok status rather than a 200 HTML `/login` page.

## Does this affect current functionality?

**No — for browser/session users, behavior is unchanged.**
- Middleware: browser users carry a cookie, so they pass today and continue to; handlers are untouched. All 18 routes under the exempted prefixes already self-authenticate (`withAuth`/`withAgentAuth` with proper permissions), so the exemption exposes nothing. The only observable change: an *unauthenticated* API request gets a **401/403 JSON** from the handler instead of a **307 → /login** (correct API behavior).
- Handlers: the dual-path keeps the **exact** `withAuth('read')` code path (RLS-scoped client + role checks) for session callers; the agent path is additive. A naive `withAuth → withAgentAuth` swap was explicitly avoided (it would bypass RLS and drop the `viewer → 403` trash check for browser users).
- Client: MCP package only; strictly improves the error an agent sees.

## Verification

- `npx tsc --noEmit` → **0 errors** (after `prebuild`).
- tcm-mcp package rebuilds cleanly (`redirect: 'manual'` compiles).
- The underlying E1–E5 REST surface + dry-run logic were confirmed correct against the live app via a cookie session (list `{items,total,has_more}`, by-display-id detail, create/update dry-run summaries — no writes).
- End-to-end agent-auth verification requires this branch deployed to a preview; the Vercel preview on this PR is the place to confirm Bearer/Clutch reaches all 5 tools.

## Notes / follow-ups (not in this PR)
- Distribution bloat (`npx github:.../TCM` pulls ~1.6 GB) — tracked separately; likely move tcm-mcp to its own repo.
- Adding the tcm-mcp package to CI typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)