### PR TITLE
chore(mcp): point .mcp.json at tcm-mcp v1.1.0 (zero-config auto-refresh)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,12 +2,8 @@
   "mcpServers": {
     "tcm": {
       "command": "npx",
-      "args": ["--yes", "github:JoinFullStackDev/tcm-mcp#v1.0.0", "--stdio"],
-      "env": {
-        "TCM_BASE_URL": "https://tcm-ochre.vercel.app",
-        "TCM_USER_TOKEN": "${TCM_USER_TOKEN}"
-      },
-      "_note": "tcm-mcp now lives in its own repo (github.com/JoinFullStackDev/tcm-mcp) — installs in ~10s / ~50MB vs the old ~1.6GB monorepo clone. It is a PRIVATE repo, so the install host needs git read access (gh auth for devs; a git token for headless agents). Export TCM_USER_TOKEN (Supabase JWT; ~1h) before launching, or set CLUTCH_API_KEY (+MCP_AGENT_USER_ID) for headless. See the tcm-mcp repo README."
+      "args": ["--yes", "github:JoinFullStackDev/tcm-mcp#v1.1.0", "--stdio"],
+      "_note": "tcm-mcp v1.1.0 auto-refreshes its Supabase token and defaults TCM_BASE_URL to production, so no env vars are needed here — the server keeps itself authenticated from ~/.tcm-mcp/session.json. One-time setup: run `npx --yes github:JoinFullStackDev/tcm-mcp#v1.1.0 login` (opens a browser once; auto-installs Playwright + Chromium into ~/.tcm-mcp). PRIVATE repo → the install host needs git read access (gh auth for devs; a git token for headless agents). Headless agents: set CLUTCH_API_KEY (+MCP_AGENT_USER_ID) instead of logging in. See the tcm-mcp repo README."
     },
     "playwright": {
       "command": "npx",


### PR DESCRIPTION
Repoints the `tcm` MCP server in `.mcp.json` from `#v1.0.0` to **`#v1.1.0`** and drops the `env` block.

tcm-mcp v1.1.0 ([JoinFullStackDev/tcm-mcp#2](https://github.com/JoinFullStackDev/tcm-mcp/pull/2)):
- **auto-refreshes** its Supabase token (no more ~1h expiry + restart), and
- **defaults `TCM_BASE_URL`** to production.

So the entry no longer needs `TCM_BASE_URL` or `TCM_USER_TOKEN`. One-time per machine:

```bash
npx --yes github:JoinFullStackDev/tcm-mcp#v1.1.0 login
```

(opens a browser once, auto-installs Playwright, writes `~/.tcm-mcp/session.json`; the server refreshes from there).

The separate `playwright` MCP entry is unchanged — tcm-mcp login bundles its own Playwright and does not depend on it.

> ⚠️ **Do not merge until the `v1.1.0` tag exists** in `JoinFullStackDev/tcm-mcp` (i.e. after that repo's PR #2 is merged and tagged). Until then `#v1.1.0` will not resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)