### PR TITLE
feat(api): agent-reachable GET /api/projects for MCP list_projects

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,12 +1,64 @@
 import { NextResponse } from 'next/server';
-import { withAuth, validationError, serverError } from '@/lib/api/helpers';
+import { withAuth, withAgentAuth, validationError, serverError } from '@/lib/api/helpers';
 import { createProjectSchema } from '@/lib/validations/project';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
-export async function GET() {
-  const auth = await withAuth('read');
-  if (!auth.ok) return auth.response;
-  const { supabase } = auth.ctx;
+const LIST_LIMIT_DEFAULT = 50;
+const LIST_LIMIT_MAX = 200;
 
+export async function GET(request: Request) {
+  // Dual auth: agents (X-Clutch-Key or Bearer JWT) authenticate via withAgentAuth so the MCP
+  // list_projects tool can reach this route; browser/session callers keep withAuth('read').
+  // Mirrors the /api/test-cases and /api/projects/{id}/suites routes (PR #105 pattern).
+  const isAgentCall =
+    request.headers.get('x-clutch-key') !== null ||
+    (request.headers.get('authorization') ?? '').startsWith('Bearer ');
+
+  let supabase: SupabaseClient;
+  if (isAgentCall) {
+    const agentAuth = await withAgentAuth();
+    if (!agentAuth.ok) return agentAuth.response;
+    supabase = agentAuth.supabase;
+  } else {
+    const auth = await withAuth('read');
+    if (!auth.ok) return auth.response;
+    supabase = auth.ctx.supabase;
+  }
+
+  const { searchParams } = new URL(request.url);
+  const search = searchParams.get('search')?.trim();
+  const lean = searchParams.get('fields') === 'lean';
+
+  // Lean projection (MCP list_projects): id + name only, no per-project count N+1 queries.
+  // Returns an { items, total, has_more } envelope with case-insensitive name search + limit,
+  // mirroring the list_test_cases lean shape.
+  if (lean) {
+    const limitParam = searchParams.get('limit');
+    const rawLimit = limitParam ? parseInt(limitParam, 10) : LIST_LIMIT_DEFAULT;
+    const clampedLimit = Math.min(
+      isNaN(rawLimit) || rawLimit < 1 ? LIST_LIMIT_DEFAULT : rawLimit,
+      LIST_LIMIT_MAX,
+    );
+
+    let query = supabase
+      .from('projects')
+      .select('id, name')
+      .order('created_at', { ascending: false });
+    if (search) query = query.ilike('name', `%${search}%`);
+
+    const { data, error } = await query;
+    if (error) return serverError(error.message);
+
+    const all = data ?? [];
+    const total = all.length;
+    const items = all
+      .slice(0, clampedLimit)
+      .map((p) => ({ project_id: p.id, name: p.name }));
+
+    return NextResponse.json({ items, total, has_more: total > items.length });
+  }
+
+  // Full projection (browser path) — unchanged shape: array enriched with suite/test-case counts.
   const { data: projects, error } = await supabase
     .from('projects')
     .select('*, suites(count)')

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -58,6 +58,9 @@ export async function middleware(request: NextRequest) {
   const isPublicPath =
     PUBLIC_PATHS.some((p) => pathname.startsWith(p)) ||
     (pathname === '/api/feedback' && request.method === 'POST') ||
+    // MCP list_projects -> GET /api/projects (list only). Handler does agent auth
+    // (withAgentAuth). Exact match so the other /api/projects/* subroutes stay cookie-gated.
+    pathname === '/api/projects' ||
     // MCP search_suite -> GET /api/projects/{id}/suites. Handler does agent auth (withAgentAuth).
     /^\/api\/projects\/[^/]+\/suites$/.test(pathname);
 


### PR DESCRIPTION
## What

Makes `GET /api/projects` reachable by the TCM MCP so the new **`list_projects`** tool (tcm-mcp issue #3, v1.2.0) can discover projects. This is the backend dependency for that tool — same class of change as **PR #105** (which did this for `/api/test-cases` and `/api/projects/{id}/suites`).

## Changes

- **`src/app/api/projects/route.ts`** — dual-path auth on `GET`:
  - agent callers (`X-Clutch-Key` or `Authorization: Bearer …`) authenticate via `withAgentAuth()`;
  - browser/session callers keep `withAuth('read')`.
  - New **lean projection** (`?fields=lean`) → `{ items: [{ project_id, name }], total, has_more }` with case-insensitive name `search` + `limit` (default 50, max 200), skipping the per-project count N+1. The full (browser) projection shape is **unchanged**.
- **`src/middleware.ts`** — exempt **exactly** `/api/projects` (list) from the cookie→`/login` redirect so agent (no-cookie) calls reach the handler. Exact match, **not** a `startsWith` prefix, so the other `/api/projects/*` subroutes stay cookie-gated (mirrors the existing `/api/projects/{id}/suites` regex).

## Auth behavior

Agent calls resolve through `withAgentAuth()` (service-role client), consistent with the sibling `/api/test-cases` and suites routes. Browser calls remain RLS-scoped via `withAuth('read')`.

## Deploy-first dependency

⚠️ **This must merge + deploy to `tcm-ochre.vercel.app` before tcm-mcp v1.2.0 is tagged.** Until it's live, `list_projects` against production degrades gracefully (307 → `SERVER_ERROR`), but the tool isn't usable.

## Test

- `tsc` clean for the changed files (only a pre-existing unrelated generated-file error remains).
- The MCP tool paths that consume this endpoint were validated end-to-end via the stdio harness against a mock implementing this exact lean shape + dual auth (all cases green in the companion tcm-mcp PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)