### PR TITLE
chore(mcp): point .mcp.json at tcm-mcp v1.2.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "tcm": {
       "command": "npx",
-      "args": ["--yes", "github:JoinFullStackDev/tcm-mcp#v1.1.0", "--stdio"],
-      "_note": "tcm-mcp v1.1.0 auto-refreshes its Supabase token and defaults TCM_BASE_URL to production, so no env vars are needed here — the server keeps itself authenticated from ~/.tcm-mcp/session.json. One-time setup: run `npx --yes github:JoinFullStackDev/tcm-mcp#v1.1.0 login` (opens a browser once; auto-installs Playwright + Chromium into ~/.tcm-mcp). PRIVATE repo → the install host needs git read access (gh auth for devs; a git token for headless agents). Headless agents: set CLUTCH_API_KEY (+MCP_AGENT_USER_ID) instead of logging in. See the tcm-mcp repo README."
+      "args": ["--yes", "github:JoinFullStackDev/tcm-mcp#v1.2.0", "--stdio"],
+      "_note": "tcm-mcp v1.2.0 adds a list_projects tool for project discovery and lets search_suite / list_test_cases take a project_name instead of a project_id. It auto-refreshes its Supabase token and defaults TCM_BASE_URL to production, so no env vars are needed here — the server keeps itself authenticated from ~/.tcm-mcp/session.json. One-time setup: run `npx --yes github:JoinFullStackDev/tcm-mcp#v1.2.0 login` (opens a browser once; auto-installs Playwright + Chromium into ~/.tcm-mcp). PRIVATE repo → the install host needs git read access (gh auth for devs; a git token for headless agents). Headless agents: set CLUTCH_API_KEY (+MCP_AGENT_USER_ID) instead of logging in. See the tcm-mcp repo README."
     },
     "playwright": {
       "command": "npx",


### PR DESCRIPTION
Bumps the pinned `tcm` MCP server tag **`#v1.1.0` → `#v1.2.0`** so anyone using the TCM repo's `.mcp.json` picks up the v1.2.0 tools shipped in #108 + tcm-mcp #4:

- **`list_projects`** — discover the projects you can see (`project_id` + `name`), with name `search`.
- **`project_name`** as an alternative to `project_id` in `search_suite` and `list_test_cases` (resolved server-side; unknown → `NOT_FOUND`, ambiguous → `AMBIGUOUS`).

Also refreshes the `_note` to mention the new capability. **No env changes** — the server still auto-refreshes its Supabase token from `~/.tcm-mcp/session.json` and defaults `TCM_BASE_URL` to production.

## Compatibility
Fully backward compatible / additive — existing `project_id`-only usage is unaffected. Same pattern as #107 (the v1.1.0 repoint).

## Verified
`v1.2.0` is tagged and live: `npx github:JoinFullStackDev/tcm-mcp#v1.2.0` cold-installs + boots, and `list_projects` → resolve-by-name → `list_test_cases` was validated end-to-end against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)