### PR TITLE
feat(api): honor X-Agent-User-Id for agent write attribution

### DIFF
--- a/src/app/api/test-cases/by-display-id/[displayId]/route.ts
+++ b/src/app/api/test-cases/by-display-id/[displayId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { withAgentAuth, notFound, serverError, validationError } from '@/lib/api/helpers';
+import { withAgentAuth, notFound, serverError, validationError, resolveAgentWriterId } from '@/lib/api/helpers';
 import { updateTestCaseSchema } from '@/lib/validations/test-case';
 import { stepSchema } from '@/lib/validations/test-step';
 import { z } from 'zod';
@@ -112,17 +112,8 @@ export async function PATCH(request: Request, context: RouteContext) {
   const { displayId } = await context.params;
   const decodedDisplayId = decodeURIComponent(displayId);
 
-  // Resolve userId for updated_by attribution (OQ-2)
-  let userId: string | null = null;
-  const authHeader = request.headers.get('authorization') ?? '';
-  if (authHeader.startsWith('Bearer ')) {
-    const { data } = await supabase.auth.getUser(authHeader.slice(7));
-    userId = data.user?.id ?? null;
-  }
-  // Headless Clutch-key path: fall back to dedicated agent profile
-  if (!userId && process.env.MCP_AGENT_USER_ID) {
-    userId = process.env.MCP_AGENT_USER_ID;
-  }
+  // Resolve updated_by attribution (OQ-2): Bearer user -> MCP X-Agent-User-Id -> default.
+  const userId: string | null = await resolveAgentWriterId(request, supabase);
 
   // OQ-6: also support ?dry_run=true query param
   const { searchParams } = new URL(request.url);

--- a/src/app/api/test-cases/route.ts
+++ b/src/app/api/test-cases/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { withAuth, withAgentAuth, validationError, serverError } from '@/lib/api/helpers';
+import { withAuth, withAgentAuth, validationError, serverError, resolveAgentWriterId } from '@/lib/api/helpers';
 import { createTestCaseSchema } from '@/lib/validations/test-case';
 import { stepSchema } from '@/lib/validations/test-step';
 import { TestCaseRepository } from '@/lib/db/test-case-repository';
@@ -257,16 +257,8 @@ export async function POST(request: Request) {
     const agentAuth = await withAgentAuth();
     if (!agentAuth.ok) return agentAuth.response;
     supabase = agentAuth.supabase;
-    // Try to resolve user from Bearer token for attribution (OQ-2)
-    const authHeader = request.headers.get('authorization') ?? '';
-    if (authHeader.startsWith('Bearer ')) {
-      const { data } = await supabase.auth.getUser(authHeader.slice(7));
-      userId = data.user?.id ?? null;
-    }
-    // Headless Clutch-key path: fall back to dedicated agent profile
-    if (!userId && process.env.MCP_AGENT_USER_ID) {
-      userId = process.env.MCP_AGENT_USER_ID;
-    }
+    // Attribution (OQ-2): Bearer user -> MCP-forwarded X-Agent-User-Id -> server default.
+    userId = await resolveAgentWriterId(request, supabase);
   } else {
     // Normal session auth for UI callers
     const auth = await withAuth('write');

--- a/src/lib/api/helpers.ts
+++ b/src/lib/api/helpers.ts
@@ -220,3 +220,32 @@ export async function withAgentAuth(): Promise<
   const supabase = await createServiceClient();
   return { ok: true, supabase };
 }
+
+
+/**
+ * Resolve the writer identity for agent-authenticated writes (created_by / updated_by).
+ *
+ * Precedence:
+ *   1. Bearer JWT       -> the real Supabase user (interactive / attributed agent).
+ *   2. X-Agent-User-Id  -> the agent id forwarded by the MCP, honored ONLY alongside a
+ *      valid X-Clutch-Key (already validated by withAgentAuth) so it can't be spoofed on
+ *      other auth paths.
+ *   3. MCP_AGENT_USER_ID -> the server-side default agent profile (back-compat).
+ *
+ * Returns null if none resolve (the caller then surfaces the NOT NULL constraint error).
+ */
+export async function resolveAgentWriterId(
+  request: Request,
+  supabase: SupabaseClient,
+): Promise<string | null> {
+  const authHeader = request.headers.get('authorization') ?? '';
+  if (authHeader.startsWith('Bearer ')) {
+    const { data } = await supabase.auth.getUser(authHeader.slice(7));
+    if (data.user?.id) return data.user.id;
+  }
+  if (request.headers.get('x-clutch-key')) {
+    const forwarded = request.headers.get('x-agent-user-id')?.trim();
+    if (forwarded) return forwarded;
+  }
+  return process.env.MCP_AGENT_USER_ID ?? null;
+}


### PR DESCRIPTION
## Problem

Headless MCP writes (Clutch, `X-Clutch-Key`) fail with:

```
null value in column "created_by" of relation "test_cases" violates not-null constraint
```

`POST /api/test-cases` and `PATCH /api/test-cases/by-display-id/{displayId}` resolve `created_by`/`updated_by` from a Bearer JWT, then fall back to the **server-side** `process.env.MCP_AGENT_USER_ID`. Under `X-Clutch-Key` there's no Bearer user, so attribution depends entirely on that env var being set **on this deployment** — and setting `MCP_AGENT_USER_ID` in Clutch's OpenClaw MCP config only affects the *MCP server process*, which never forwarded it here. Result: `userId = null` → 500.

**Diagnosis was verified empirically:** the same MCP `create_test_case` tool against this same route succeeds via **Bearer** (`created_by` resolves from the JWT) and fails only via **clutch-key** — isolating the gap to agent-identity resolution, not the MCP or the write logic.

## Change

New **`resolveAgentWriterId(request, supabase)`** in `lib/api/helpers.ts`, precedence:

1. **Bearer JWT** → the real Supabase user.
2. **`X-Agent-User-Id`** → the agent id forwarded by the MCP, honored **only** alongside a valid `X-Clutch-Key` (already validated by `withAgentAuth`, so it can't be spoofed on other auth paths).
3. **`MCP_AGENT_USER_ID`** env → server-side default (back-compat).

Wired into both agent-reachable write paths (`POST /api/test-cases`, by-display-id `PATCH`), replacing the duplicated inline blocks.

## Pairs with

**tcm-mcp v1.3.0** (JoinFullStackDev/tcm-mcp#5) forwards `MCP_AGENT_USER_ID` as `X-Agent-User-Id` in clutch mode. Together they make the OpenClaw MCP config the source of truth and let distinct agents (axel/riff/arc) attribute their own writes.

## Compatibility

Fully backward compatible. Bearer/session paths unchanged. Setting `MCP_AGENT_USER_ID` in **this app's** env still works as a fallback — so the immediate ops unblock (set it in Vercel) and this PR compose: the header wins when present, the env fills in when not.

## Test

`tsc` clean for the changed files. The MCP→header→`created_by` contract was validated end-to-end via the stdio harness against a mock mirroring this precedence: clutch + agent id → header → `created_by` set (201); clutch without it → the exact `created_by`-null 500; bearer → unchanged. Full live verification once merged + deployed (Clutch retries T3.3/T4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)