### PR TITLE
chore(mcp): point .mcp.json at tcm-mcp v1.3.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "tcm": {
       "command": "npx",
-      "args": ["--yes", "github:JoinFullStackDev/tcm-mcp#v1.2.0", "--stdio"],
-      "_note": "tcm-mcp v1.2.0 adds a list_projects tool for project discovery and lets search_suite / list_test_cases take a project_name instead of a project_id. It auto-refreshes its Supabase token and defaults TCM_BASE_URL to production, so no env vars are needed here — the server keeps itself authenticated from ~/.tcm-mcp/session.json. One-time setup: run `npx --yes github:JoinFullStackDev/tcm-mcp#v1.2.0 login` (opens a browser once; auto-installs Playwright + Chromium into ~/.tcm-mcp). PRIVATE repo → the install host needs git read access (gh auth for devs; a git token for headless agents). Headless agents: set CLUTCH_API_KEY (+MCP_AGENT_USER_ID) instead of logging in. See the tcm-mcp repo README."
+      "args": ["--yes", "github:JoinFullStackDev/tcm-mcp#v1.3.0", "--stdio"],
+      "_note": "tcm-mcp v1.3.0 forwards MCP_AGENT_USER_ID as X-Agent-User-Id so headless (Clutch) writes attribute created_by/updated_by correctly. It also has a list_projects tool for project discovery and lets search_suite / list_test_cases take a project_name instead of a project_id. It auto-refreshes its Supabase token and defaults TCM_BASE_URL to production, so no env vars are needed here — the server keeps itself authenticated from ~/.tcm-mcp/session.json. One-time setup: run `npx --yes github:JoinFullStackDev/tcm-mcp#v1.3.0 login` (opens a browser once; auto-installs Playwright + Chromium into ~/.tcm-mcp). PRIVATE repo → the install host needs git read access (gh auth for devs; a git token for headless agents). Headless agents: set CLUTCH_API_KEY (+MCP_AGENT_USER_ID) instead of logging in. See the tcm-mcp repo README."
     },
     "playwright": {
       "command": "npx",


### PR DESCRIPTION
Bumps the pinned `tcm` MCP server tag **`#v1.2.0` → `#v1.3.0`** so anyone using the TCM repo's `.mcp.json` picks up v1.3.0 (JoinFullStackDev/tcm-mcp#5):

- **Headless write attribution** — the MCP now forwards `MCP_AGENT_USER_ID` as `X-Agent-User-Id`, so Clutch/agent `create`/`update` calls resolve `created_by`/`updated_by` (pairs with #110, already merged).
- Carries forward the v1.2.0 `list_projects` tool + `project_name` resolution.

Also refreshes the `_note`. **No env changes** for interactive users — the server still auto-refreshes from `~/.tcm-mcp/session.json` and defaults to production.

## Compatibility
Fully backward compatible / additive. Same pattern as #107 (v1.1.0) and #109 (v1.2.0). Note: this repoints the **repo's** `.mcp.json` (interactive Claude Code users); Clutch/OpenClaw has its own separate config that must be bumped to `#v1.3.0` independently.

## Verified
`v1.3.0` is tagged and live: cold-installed from the tag, clutch mode emits `X-Agent-User-Id` and the writer id resolves from it (validated via the stdio harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)