### PR TITLE
chore(mcp): point .mcp.json at tcm-mcp v1.4.0 (list_suites + suite group)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "tcm": {
       "command": "npx",
-      "args": ["--yes", "github:JoinFullStackDev/tcm-mcp#v1.3.0", "--stdio"],
-      "_note": "tcm-mcp v1.3.0 forwards MCP_AGENT_USER_ID as X-Agent-User-Id so headless (Clutch) writes attribute created_by/updated_by correctly. It also has a list_projects tool for project discovery and lets search_suite / list_test_cases take a project_name instead of a project_id. It auto-refreshes its Supabase token and defaults TCM_BASE_URL to production, so no env vars are needed here — the server keeps itself authenticated from ~/.tcm-mcp/session.json. One-time setup: run `npx --yes github:JoinFullStackDev/tcm-mcp#v1.3.0 login` (opens a browser once; auto-installs Playwright + Chromium into ~/.tcm-mcp). PRIVATE repo → the install host needs git read access (gh auth for devs; a git token for headless agents). Headless agents: set CLUTCH_API_KEY (+MCP_AGENT_USER_ID) instead of logging in. See the tcm-mcp repo README."
+      "args": ["--yes", "github:JoinFullStackDev/tcm-mcp#v1.4.0", "--stdio"],
+      "_note": "tcm-mcp v1.4.0 adds a list_suites tool that enumerates every suite in a project (each with its group role-label and test_case_count); search_suite now also returns group/test_case_count. v1.3.0 forwards MCP_AGENT_USER_ID as X-Agent-User-Id so headless (Clutch) writes attribute created_by/updated_by correctly. It also has a list_projects tool for project discovery and lets search_suite / list_test_cases take a project_name instead of a project_id. It auto-refreshes its Supabase token and defaults TCM_BASE_URL to production, so no env vars are needed here — the server keeps itself authenticated from ~/.tcm-mcp/session.json. One-time setup: run `npx --yes github:JoinFullStackDev/tcm-mcp#v1.4.0 login` (opens a browser once; auto-installs Playwright + Chromium into ~/.tcm-mcp). PRIVATE repo → the install host needs git read access (gh auth for devs; a git token for headless agents). Headless agents: set CLUTCH_API_KEY (+MCP_AGENT_USER_ID) instead of logging in. See the tcm-mcp repo README."
     },
     "playwright": {
       "command": "npx",


### PR DESCRIPTION
Repoints the monorepo `.mcp.json` from `#v1.3.0` → **`#v1.4.0`** and refreshes the `_note`.

**v1.4.0** ([tcm-mcp #6](https://github.com/JoinFullStackDev/tcm-mcp/pull/6), tagged) adds a **`list_suites`** tool — enumerates every suite in a project, each with its `group` (role label) and `test_case_count` — and surfaces `group`/`test_case_count` on `search_suite` too. Cold-install from the tag verified: boots clean, `list_suites` exposed.

Interactive Claude-Code-in-monorepo config only — **no env changes**, no impact on headless Clutch/Torque (which pins its own OpenClaw config). The separate `playwright` MCP entry is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)