### PR TITLE
fix: allow hyphens in suite prefix field

### DIFF
--- a/src/lib/validations/suite.ts
+++ b/src/lib/validations/suite.ts
@@ -8,7 +8,7 @@ export const createSuiteSchema = z.object({
     .min(1, 'Prefix is required')
     .max(10, 'Prefix must be 10 characters or less')
     .transform((v) => v.toUpperCase())
-    .refine((v) => /^[A-Z0-9]+$/.test(v), 'Prefix must be alphanumeric'),
+    .refine((v) => /^[A-Z0-9-]+$/.test(v), 'Prefix must be alphanumeric and may include hyphens'),
   description: z.string().trim().max(1000).nullable().optional(),
   tags: z.array(z.string().trim().max(50)).optional().default([]),
   group: z.string().trim().max(50).nullable().optional(),
@@ -22,7 +22,7 @@ export const updateSuiteSchema = z.object({
     .min(1)
     .max(10)
     .transform((v) => v.toUpperCase())
-    .refine((v) => /^[A-Z0-9]+$/.test(v), 'Prefix must be alphanumeric')
+    .refine((v) => /^[A-Z0-9-]+$/.test(v), 'Prefix must be alphanumeric and may include hyphens')
     .optional(),
   description: z.string().trim().max(1000).nullable().optional(),
   tags: z.array(z.string().trim().max(50)).optional(),


### PR DESCRIPTION
## What
Updates suite prefix validation to allow hyphens (e.g. `CF-CFA`).

## Why
The regex `^[A-Z0-9]+$` was rejecting valid hyphenated prefixes. Existing suites like CF-DIST, CF-HUB, CF-ORD were created via the MCP path which bypassed this validation — inconsistent UX for anyone editing via the UI.

## Change
`src/lib/validations/suite.ts` — both `createSuiteSchema` and `updateSuiteSchema` regex updated from `^[A-Z0-9]+$` to `^[A-Z0-9-]+$`.

No DB migration required — prefix column is plain `text`, no character-level constraint at the DB layer.